### PR TITLE
Add scalable logo image to header

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,9 +9,14 @@
 <body>
   <div class="wrap">
     <header>
-      <h1>ShagWekker</h1>
+      <h1>ShagWekker <img src="logo.svg" alt="Logo" id="logoImage" /></h1>
       <div id="clock" aria-live="polite" title="Current local time"></div>
     </header>
+
+    <div class="controls" id="imgControls">
+      <label for="imgSize">Image size</label>
+      <input type="range" id="imgSize" min="50" max="300" value="150" />
+    </div>
 
     <form id="addForm" class="controls" autocomplete="off">
       <input type="time" id="timeInput" required aria-label="Add time (HH:MM)" />

--- a/logo.svg
+++ b/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" fill="#6aa2ff"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="40" fill="#fff">S</text>
+</svg>

--- a/script.js
+++ b/script.js
@@ -79,6 +79,8 @@ const clockEl = document.getElementById('clock');
 const addForm = document.getElementById('addForm');
 const timeInput = document.getElementById('timeInput');
 const resetBtn = document.getElementById('resetBtn');
+const imgSizeInput = document.getElementById('imgSize');
+const logoImage = document.getElementById('logoImage');
 
 let TIMES = loadTimes();
 
@@ -150,6 +152,14 @@ resetBtn.addEventListener('click', ()=>{
   buildUI();
   update();
 });
+
+if(imgSizeInput && logoImage){
+  const updateImageSize = () => {
+    logoImage.style.width = imgSizeInput.value + 'px';
+  };
+  imgSizeInput.addEventListener('input', updateImageSize);
+  updateImageSize();
+}
 
 buildUI();
 update();

--- a/style.css
+++ b/style.css
@@ -15,6 +15,9 @@ body{
 .wrap{width:min(960px,100%);}
 header{display:flex; gap:16px; align-items:end; justify-content:space-between; margin-bottom:16px}
 h1{font-size:20px; margin:0; letter-spacing:.3px; font-weight:700; color:var(--ink)}
+#imgControls{align-items:center}
+h1 img{margin-left:8px; vertical-align:middle; width:150px; height:auto}
+#imgSize{flex:1}
 #clock{font-variant-numeric:tabular-nums; font-weight:700; font-size:28px}
 .cards{display:grid; grid-template-columns:repeat(auto-fit, minmax(240px,1fr)); gap:12px}
 .card{


### PR DESCRIPTION
## Summary
- Display a logo image next to the ShagWekker title
- Provide a slider to manually adjust the logo size
- Style and script updates to apply selected image width

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b961e1519483258dfffa51902b78f0