### PR TITLE
Add placeholder image after title with basic styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <div class="wrap">
     <header>
       <h1 class="ShagWekkerTitel">ShagWekker</h1>
+      <img id="title-image" src="placeholder.png" alt="Placeholder image" /> <!-- Image placeholder; replace src when ready -->
       <div id="clock" aria-live="polite" title="Current local time"></div>
     </header>
 

--- a/style.css
+++ b/style.css
@@ -18,6 +18,12 @@ body{
 header{display:flex; gap:16px; align-items:end; justify-content:space-between; margin-bottom:16px}
 h1{margin:0; letter-spacing:.3px; font-weight:700; color:var(--ink)}
 .ShagWekkerTitel{font-size:var(--title-size); /* allows adjusting ShagWekker title size */}
+#title-image{
+  width:150px; /* sets image width */
+  height:150px; /* sets image height */
+  display:block; /* ensures image is on its own line */
+  margin:8px auto; /* centers image horizontally and adds top/bottom margin */
+}
 #clock{font-variant-numeric:tabular-nums; font-weight:700; font-size:28px}
 .cards{display:grid; grid-template-columns:repeat(auto-fit, minmax(240px,1fr)); gap:12px}
 .card{


### PR DESCRIPTION
## Summary
- Add placeholder image after the main "ShagWekker" title
- Define placeholder image size and centering with explanatory comments

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b980adfc488325a7dee6fe5df57edb