### PR TITLE
Add about page and header navigation

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>About - ShagWekker</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="wrap">
+    <header>
+      <h1 class="ShagWekkerTitel">ShagWekker</h1>
+      <div class="header-right">
+        <nav><a href="index.html">Home</a></nav>
+      </div>
+    </header>
+    <main>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    </main>
+  </div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -10,8 +10,11 @@
   <div class="wrap">
     <header>
       <h1 class="ShagWekkerTitel">ShagWekker</h1>
-      <img id="title-image" src="assets/shag.png" alt="Placeholder image" /> <!-- Image placeholder; replace src when ready -->
-      <div id="clock" aria-live="polite" title="Current local time"></div>
+      <div class="header-right">
+        <img id="title-image" src="assets/shag.png" alt="Placeholder image" /> <!-- Image placeholder; replace src when ready -->
+        <nav><a href="about.html">About</a></nav>
+        <div id="clock" aria-live="polite" title="Current local time"></div>
+      </div>
     </header>
 
     <form id="addForm" class="controls" autocomplete="off">

--- a/style.css
+++ b/style.css
@@ -18,6 +18,9 @@ body{
 header{display:flex; gap:16px; align-items:end; justify-content:space-between; margin-bottom:16px}
 h1{margin:0; letter-spacing:.3px; font-weight:700; color:var(--ink)}
 .ShagWekkerTitel{font-size:var(--title-size); /* allows adjusting ShagWekker title size */}
+.header-right{display:flex; gap:16px; align-items:end;}
+header nav a{color:var(--ink); text-decoration:none;}
+header nav a:hover{text-decoration:underline;}
 #title-image{
   width:150px; /* sets image width */
   height:200px; /* sets image height */


### PR DESCRIPTION
## Summary
- Add navigation link in main header pointing to new About page
- Style header navigation and layout with new `.header-right` container
- Provide simple About page using existing styles and lorem ipsum placeholder text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be7bf537788325a11d1b4485691c75