### PR TITLE
Add header navigation and blank about page

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>About - ShagWekker</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="wrap">
+    <header>
+      <h1 class="ShagWekkerTitel">ShagWekker</h1>
+      <img id="title-image" src="assets/shag.png" alt="Placeholder image" />
+      <div class="header-right">
+        <nav class="main-nav">
+          <a href="index.html">Home</a>
+        </nav>
+      </div>
+    </header>
+    <main>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    </main>
+  </div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,12 @@
     <header>
       <h1 class="ShagWekkerTitel">ShagWekker</h1>
       <img id="title-image" src="assets/shag.png" alt="Placeholder image" /> <!-- Image placeholder; replace src when ready -->
-      <div id="clock" aria-live="polite" title="Current local time"></div>
+      <div class="header-right">
+        <div id="clock" aria-live="polite" title="Current local time"></div>
+        <nav class="main-nav">
+          <a href="about.html">About</a>
+        </nav>
+      </div>
     </header>
 
     <form id="addForm" class="controls" autocomplete="off">

--- a/style.css
+++ b/style.css
@@ -16,6 +16,9 @@ body{
 }
 .wrap{width:min(960px,100%);}
 header{display:flex; gap:16px; align-items:end; justify-content:space-between; margin-bottom:16px}
+.header-right{display:flex; flex-direction:column; align-items:flex-end; gap:8px}
+.main-nav a{color:var(--ink); text-decoration:none}
+.main-nav a:hover{text-decoration:underline}
 h1{margin:0; letter-spacing:.3px; font-weight:700; color:var(--ink)}
 .ShagWekkerTitel{font-size:var(--title-size); /* allows adjusting ShagWekker title size */}
 #title-image{


### PR DESCRIPTION
## Summary
- add header link to new About page
- style header navigation
- create simple About page with lorem ipsum text using existing styles

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be7bf537788325a11d1b4485691c75