### PR TITLE
Update default routine for shag-inspired cadence

### DIFF
--- a/style.css
+++ b/style.css
@@ -419,43 +419,277 @@ main {
 
 .timeline {
   list-style: none;
-  padding: 0;
   margin: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
+  padding: 0;
+  display: grid;
+  gap: 1.25rem;
+  position: relative;
+  padding-left: 2.25rem;
+}
+
+.timeline[data-state="populated"]::before {
+  content: "";
+  position: absolute;
+  top: 0.75rem;
+  bottom: 0.75rem;
+  left: 1.15rem;
+  width: 2px;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--accent) 50%, transparent) 0%,
+    rgba(255, 255, 255, 0.08) 45%,
+    rgba(255, 255, 255, 0.02) 100%
+  );
+  pointer-events: none;
 }
 
 .timeline__item {
-  padding: 1rem 1.25rem;
-  border-radius: var(--radius-md);
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  position: relative;
   display: grid;
-  gap: 0.4rem;
+  grid-template-columns: auto 1fr;
+  gap: 1.25rem;
+  padding: 1.15rem 1.35rem 1.25rem 1.35rem;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 18px 42px -24px rgba(5, 11, 26, 0.9);
+  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition), background var(--transition);
+  backdrop-filter: blur(18px);
+  isolation: isolate;
+}
+
+.timeline__item[data-color] {
+  border-color: color-mix(in srgb, var(--timeline-accent) 35%, rgba(255, 255, 255, 0.18));
+  background: linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--timeline-accent) 20%, transparent) 0%,
+      rgba(17, 24, 39, 0.35) 42%,
+      rgba(255, 255, 255, 0.02) 100%
+    ),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02));
+}
+
+.timeline__item[data-color]::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(
+    circle at top right,
+    color-mix(in srgb, var(--timeline-accent) 28%, transparent) 0%,
+    transparent 60%
+  );
+  opacity: 0.9;
+  pointer-events: none;
+  mix-blend-mode: screen;
+}
+
+.timeline__item:hover {
+  transform: translateX(6px) translateY(-3px);
+  box-shadow: 0 24px 54px -18px color-mix(in srgb, var(--timeline-accent, var(--accent)) 50%, rgba(4, 7, 18, 0.75));
+  border-color: color-mix(in srgb, var(--timeline-accent, var(--accent)) 55%, rgba(255, 255, 255, 0.28));
+}
+
+.timeline__decor {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  width: 2.35rem;
+  padding-top: 0.15rem;
+}
+
+.timeline__dot {
+  position: relative;
+  z-index: 1;
+  width: 0.95rem;
+  height: 0.95rem;
+  border-radius: 999px;
+  background: var(--timeline-accent, var(--accent));
+  border: 2px solid rgba(255, 255, 255, 0.75);
+  box-shadow: 0 0 0 6px color-mix(in srgb, var(--timeline-accent, var(--accent)) 15%, transparent);
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.timeline__item:hover .timeline__dot {
+  transform: scale(1.08);
+  box-shadow: 0 0 0 10px color-mix(in srgb, var(--timeline-accent, var(--accent)) 20%, transparent);
+}
+
+.timeline__glow {
+  position: absolute;
+  top: -0.75rem;
+  left: 50%;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 999px;
+  background: radial-gradient(
+    circle,
+    color-mix(in srgb, var(--timeline-accent, var(--accent)) 38%, transparent) 0%,
+    transparent 65%
+  );
+  transform: translateX(-50%);
+  animation: timelinePulse 4.5s ease-in-out infinite;
+  pointer-events: none;
+}
+
+.timeline__body {
+  display: grid;
+  gap: 0.55rem;
 }
 
 .timeline__header {
   display: flex;
   justify-content: space-between;
   align-items: baseline;
-  gap: 0.75rem;
+  gap: 1rem;
 }
 
 .timeline__label {
   margin: 0;
-  font-weight: 600;
+  font-weight: 700;
+  font-size: 1.08rem;
 }
 
 .timeline__time {
   font-variant-numeric: tabular-nums;
-  color: var(--muted);
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.timeline__detail {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 0.93rem;
+  line-height: 1.45;
+}
+
+.timeline__meta {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.timeline__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.85);
 }
 
 .timeline__count {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.4rem;
   margin: 0;
-  font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.96rem;
+  color: rgba(255, 255, 255, 0.9);
+  font-variant-numeric: tabular-nums;
+}
+
+.timeline__count-label {
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.timeline__progress {
+  position: relative;
+  margin-top: 0.25rem;
+  height: 4px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.timeline__progress span {
+  display: block;
+  height: 100%;
+  width: var(--fill, 0%);
+  background: linear-gradient(90deg, var(--timeline-accent, var(--accent)) 0%, color-mix(in srgb, var(--timeline-accent, var(--accent)) 35%, #ffffff) 100%);
+  transition: width var(--transition);
+}
+
+.timeline--compact .timeline__item {
+  padding: 0.95rem 1.1rem 1.05rem 1.1rem;
+  gap: 1rem;
+}
+
+.timeline--compact .timeline__label {
+  font-size: 1rem;
+}
+
+.timeline--compact .timeline__detail {
+  display: none;
+}
+
+.timeline--compact .timeline__count {
+  font-size: 0.88rem;
+}
+
+.timeline--compact .timeline__pill {
+  font-size: 0.68rem;
+}
+
+.timeline--compact .timeline__progress {
+  margin-top: 0.15rem;
+}
+
+.timeline__item--empty {
+  grid-template-columns: 1fr;
+  text-align: center;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px dashed rgba(255, 255, 255, 0.18);
+  box-shadow: none;
+}
+
+.timeline__item--empty .timeline__label {
+  font-size: 1rem;
+}
+
+.timeline__item--empty .timeline__detail {
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.timeline__item--empty::after,
+.timeline__item--empty .timeline__decor,
+.timeline__item--empty .timeline__progress {
+  display: none;
+}
+
+@keyframes timelinePulse {
+  0%,
+  100% {
+    opacity: 0.6;
+    transform: translateX(-50%) scale(1);
+  }
+  50% {
+    opacity: 1;
+    transform: translateX(-50%) scale(1.18);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .timeline__item {
+    transition: none;
+  }
+  .timeline__item:hover {
+    transform: none;
+  }
+  .timeline__glow {
+    animation: none;
+  }
+  .timeline__progress span {
+    transition: none;
+  }
 }
 
 .customize {


### PR DESCRIPTION
## Summary
- replace the default routine with shag-geïnspireerde labels en beschrijvingen
- remove the Sunrise Stretch card, add a 14:30 middag shag moment, and restrict late cues to Mon/Wed/Thu
- support Mon/Wed/Thu recurrences in the timeline and countdown logic

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cbb946bce48325b46e7b7c387bb601