### PR TITLE
Fix timeline glow overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -473,6 +473,7 @@ main {
   content: "";
   position: absolute;
   inset: 0;
+  border-radius: inherit;
   background: radial-gradient(
     circle at top right,
     color-mix(in srgb, var(--timeline-accent) 28%, transparent) 0%,


### PR DESCRIPTION
## Summary
- ensure the timeline accent pseudo-element inherits the card border radius to prevent visual overflow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0f03067248325bf5d4d0b6d38b596