### PR TITLE
Create interactive insights link hub

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,20 +163,103 @@
           </div>
           <p class="section-header__hint">Plug analytics or productivity exports into your own visualization here.</p>
         </header>
-        <div class="insights__grid">
-          <figure class="insights__figure">
-            <img src="assets/insights-placeholder.svg" alt="Placeholder insights graphic" loading="lazy" />
-            <figcaption>Replace this chart with your data-driven story.</figcaption>
-          </figure>
-          <div class="insights__copy">
-            <h3>Keep evolving</h3>
-            <p>Every element of the interface responds to the data structure in <code>script.js</code>. Add new categories, feed live data, or wire this panel into the tools you already love.</p>
-            <ul>
-              <li>Drag and drop hooks are ready for expansion.</li>
-              <li>Timeline items auto-sort and refresh every second.</li>
-              <li>Accent colors cascade across cards and call-to-actions.</li>
-            </ul>
-          </div>
+        <div class="insights__hub" role="list">
+          <a
+            class="insight-tile"
+            href="https://example.com/routine-lab"
+            role="listitem"
+            style="--tile-accent: #6aa2ff"
+          >
+            <span class="insight-tile__glow" aria-hidden="true"></span>
+            <span class="insight-tile__icon" aria-hidden="true">
+              <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                <rect
+                  x="9"
+                  y="9"
+                  width="30"
+                  height="30"
+                  rx="12"
+                  ry="12"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2.5"
+                  opacity="0.82"
+                />
+                <path
+                  d="M16 29c2.4-4.6 6.1-7.4 11.2-7.4 3.4 0 5.9 1.6 7.8 3.8"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  opacity="0.9"
+                />
+                <circle cx="20.5" cy="21" r="2.5" fill="currentColor" />
+              </svg>
+            </span>
+            <span class="insight-tile__label">Routine lab</span>
+            <span class="insight-tile__hint">Prototype new cadence flows.</span>
+          </a>
+
+          <a
+            class="insight-tile"
+            href="https://example.com/signal-archive"
+            role="listitem"
+            style="--tile-accent: #9f6aff"
+          >
+            <span class="insight-tile__glow" aria-hidden="true"></span>
+            <span class="insight-tile__icon" aria-hidden="true">
+              <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                <path
+                  d="M12 33.5h24M15.5 24h17M19 14.5h10"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="3"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  opacity="0.88"
+                />
+                <circle cx="16" cy="24" r="3" fill="currentColor" opacity="0.88" />
+                <circle cx="32" cy="14.5" r="3" fill="currentColor" opacity="0.88" />
+                <circle cx="24" cy="33.5" r="3.2" fill="currentColor" />
+              </svg>
+            </span>
+            <span class="insight-tile__label">Signal archive</span>
+            <span class="insight-tile__hint">Curate past peaks and dips.</span>
+          </a>
+
+          <a
+            class="insight-tile"
+            href="https://example.com/community-share"
+            role="listitem"
+            style="--tile-accent: #ff7f8c"
+          >
+            <span class="insight-tile__glow" aria-hidden="true"></span>
+            <span class="insight-tile__icon" aria-hidden="true">
+              <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                <path
+                  d="M17.5 18.5c0 3.3-2.6 5.9-5.9 5.9s-5.9-2.6-5.9-5.9 2.6-5.9 5.9-5.9 5.9 2.6 5.9 5.9Zm29.8 11.3c0 3.3-2.6 5.9-5.9 5.9s-5.9-2.6-5.9-5.9 2.6-5.9 5.9-5.9 5.9 2.6 5.9 5.9Zm-11.6-16c0 3.9-3.2 7-7 7s-7-3.2-7-7 3.2-7 7-7 7 3.1 7 7Z"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2.8"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  opacity="0.9"
+                />
+                <path
+                  d="m15.5 22.4 6.5 3.6m4.1-8.1 5.9 3.3m-4.8 4.8 6.2 3.7"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2.6"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  opacity="0.88"
+                />
+              </svg>
+            </span>
+            <span class="insight-tile__label">Community share</span>
+            <span class="insight-tile__hint">Sync with trusted collaborators.</span>
+          </a>
         </div>
       </section>
     </main>

--- a/index.html
+++ b/index.html
@@ -197,13 +197,13 @@
                 <circle cx="20.5" cy="21" r="2.5" fill="currentColor" />
               </svg>
             </span>
-            <span class="insight-tile__label">Routine lab</span>
-            <span class="insight-tile__hint">Prototype new cadence flows.</span>
+            <span class="insight-tile__label">IsHetAlPauze.nl</span>
+            <span class="insight-tile__hint">De inferieure voorganger van ShagWekker.</span>
           </a>
 
           <a
             class="insight-tile"
-            href="https://example.com/signal-archive"
+            href="https://ishetalpauze.nl/"
             role="listitem"
             style="--tile-accent: #9f6aff"
           >

--- a/style.css
+++ b/style.css
@@ -851,42 +851,118 @@ button {
   padding: clamp(1.8rem, 4vw, 2.6rem);
 }
 
-.insights__grid {
+.insights__hub {
+  margin-top: clamp(1.5rem, 3vw, 2.4rem);
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: var(--grid-gap);
-  align-items: center;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: clamp(1rem, 2.4vw, 1.75rem);
 }
 
-.insights__figure {
-  margin: 0;
-  background: rgba(255, 255, 255, 0.04);
-  padding: clamp(1.2rem, 3vw, 1.8rem);
+.insight-tile {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: flex-start;
+  padding: clamp(1.2rem, 3vw, 1.6rem);
   border-radius: var(--radius-md);
-  text-align: center;
-  border: 1px dashed rgba(255, 255, 255, 0.12);
+  color: inherit;
+  text-decoration: none;
+  background: linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--tile-accent, var(--accent)) 18%, rgba(255, 255, 255, 0.06)) 0%,
+      rgba(255, 255, 255, 0.02) 100%
+    ),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.02));
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 18px 42px -24px rgba(5, 11, 26, 0.9);
+  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition),
+    background var(--transition);
+  backdrop-filter: blur(18px);
+  isolation: isolate;
+  overflow: hidden;
+  min-height: 168px;
 }
 
-.insights__figure img {
-  width: min(100%, 420px);
+.insight-tile__glow {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(
+    circle at 75% 15%,
+    color-mix(in srgb, var(--tile-accent, var(--accent)) 45%, transparent) 0%,
+    transparent 70%
+  );
+  opacity: 0.75;
+  pointer-events: none;
+  mix-blend-mode: screen;
+  transition: opacity var(--transition), transform var(--transition);
 }
 
-.insights__figure figcaption {
-  font-size: 0.85rem;
-  color: var(--muted);
-  margin-top: 0.75rem;
-}
-
-.insights__copy h3 {
-  margin-top: 0;
-  margin-bottom: 0.75rem;
-}
-
-.insights__copy ul {
-  padding-left: 1.2rem;
-  margin: 0.75rem 0 0;
+.insight-tile__icon {
+  position: relative;
+  z-index: 1;
+  width: 76px;
+  height: 76px;
+  border-radius: 24px;
   display: grid;
-  gap: 0.4rem;
+  place-items: center;
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--tile-accent, var(--accent)) 65%, rgba(255, 255, 255, 0.08)) 0%,
+    color-mix(in srgb, var(--tile-accent, var(--accent)) 28%, rgba(10, 16, 30, 0.95)) 100%
+  );
+  box-shadow: 0 18px 42px -26px color-mix(in srgb, var(--tile-accent, var(--accent)) 55%, rgba(2, 5, 14, 0.75));
+  color: #ffffff;
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.insight-tile__icon svg {
+  width: 34px;
+  height: 34px;
+}
+
+.insight-tile__label {
+  position: relative;
+  z-index: 1;
+  font-weight: 600;
+  font-size: 1.05rem;
+  letter-spacing: 0.01em;
+}
+
+.insight-tile__hint {
+  position: relative;
+  z-index: 1;
+  color: var(--muted);
+  font-size: 0.9rem;
+  max-width: 22ch;
+}
+
+.insight-tile:hover {
+  transform: translateX(6px) translateY(-3px);
+  border-color: color-mix(in srgb, var(--tile-accent, var(--accent)) 55%, rgba(255, 255, 255, 0.26));
+  box-shadow: 0 24px 54px -18px color-mix(in srgb, var(--tile-accent, var(--accent)) 50%, rgba(4, 7, 18, 0.75));
+  background: linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--tile-accent, var(--accent)) 28%, rgba(255, 255, 255, 0.12)) 0%,
+      rgba(255, 255, 255, 0.04) 100%
+    ),
+    linear-gradient(135deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
+}
+
+.insight-tile:hover .insight-tile__icon {
+  transform: translateY(-2px) scale(1.05);
+  box-shadow: 0 24px 54px -20px color-mix(in srgb, var(--tile-accent, var(--accent)) 62%, rgba(4, 7, 18, 0.72));
+}
+
+.insight-tile:hover .insight-tile__glow {
+  opacity: 0.95;
+  transform: scale(1.05);
+}
+
+.insight-tile:focus-visible {
+  outline: 3px solid color-mix(in srgb, var(--tile-accent, var(--accent)) 55%, rgba(255, 255, 255, 0.4));
+  outline-offset: 4px;
 }
 
 .site-footer {


### PR DESCRIPTION
## Summary
- replace the placeholder Pattern Explorer content with a trio of interactive link tiles that mirror the Upcoming Timeline hover motion
- craft compact iOS-inspired icon buttons with inline SVG artwork and accent overrides for quick link updates
- add new styling for the insights hub including glow, focus, and hover treatments that respond to cursor movement

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0f4d923f0832583fc5a863e676173