### PR TITLE
Add yellow Jensen link button to insights section

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,6 +163,9 @@
           </div>
           <p class="section-header__hint">Plug analytics or productivity exports into your own visualization here.</p>
         </header>
+        <div class="insights__actions">
+          <a class="btn sunny" href="https://jensen.nl/">Visit Jensen.nl</a>
+        </div>
         <div class="insights__hub" role="list">
           <a
             class="insight-tile"

--- a/style.css
+++ b/style.css
@@ -794,7 +794,7 @@ button {
   box-shadow: 0 22px 44px rgba(106, 162, 255, 0.5);
 }
 
-.btn.outline {
+.btn.outline { 
   background: rgba(255, 255, 255, 0.08);
   border: 1px solid rgba(255, 255, 255, 0.2);
   color: var(--ink);
@@ -803,6 +803,18 @@ button {
 .btn.ghost {
   background: rgba(255, 255, 255, 0.08);
   color: var(--ink);
+}
+
+.btn.sunny {
+  background: linear-gradient(135deg, #ffe066, #ffb347);
+  color: #2d1600;
+  box-shadow: 0 18px 38px rgba(255, 193, 67, 0.35);
+}
+
+.btn.sunny:hover,
+.btn.sunny:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 22px 44px rgba(255, 193, 67, 0.45);
 }
 
 .btn.ghost:hover,
@@ -849,6 +861,12 @@ button {
   border: 1px solid rgba(255, 255, 255, 0.08);
   box-shadow: var(--shadow-xl);
   padding: clamp(1.8rem, 4vw, 2.6rem);
+}
+
+.insights__actions {
+  margin-top: clamp(1rem, 2.5vw, 1.5rem);
+  display: flex;
+  flex-wrap: wrap;
 }
 
 .insights__hub {


### PR DESCRIPTION
## Summary
- add a Jensen.nl call-to-action button under the "Visualize your cadence" heading
- style a new sunny button variant and insights action layout spacing

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d0f8f10a408325a004b944ce09a033