### PR TITLE
Add JENSEN insight link tile

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,6 +260,39 @@
             <span class="insight-tile__label">Community share</span>
             <span class="insight-tile__hint">Sync with trusted collaborators.</span>
           </a>
+
+          <a
+            class="insight-tile"
+            href="https://jensen.nl/"
+            role="listitem"
+            style="--tile-accent: #ffd447"
+          >
+            <span class="insight-tile__glow" aria-hidden="true"></span>
+            <span class="insight-tile__icon" aria-hidden="true">
+              <svg viewBox="0 0 48 48" xmlns="http://www.w3.org/2000/svg" focusable="false">
+                <circle
+                  cx="24"
+                  cy="24"
+                  r="11.5"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="3"
+                  opacity="0.85"
+                />
+                <path
+                  d="M24 11v6m0 14v6m13-13h-6m-14 0h-6m18.5-9 4.2-4.2m-21 21 4.2-4.2m12.6 0 4.2 4.2m-21-21 4.2 4.2"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2.6"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  opacity="0.88"
+                />
+              </svg>
+            </span>
+            <span class="insight-tile__label">JENSEN</span>
+            <span class="insight-tile__hint">Ontdek meer via JENSEN.nl.</span>
+          </a>
         </div>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- add a fourth insights tile that links to JENSEN.nl
- style the new tile with a yellow accent and custom icon to match existing layout

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d110d577b08325aac94ca359b56b4c