### PR TITLE
Add resource library page and navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
         <a href="#planner">Planner</a>
         <a href="#customize">Customize</a>
         <a href="#insights">Insights</a>
+        <a href="library.html">Downloads</a>
       </nav>
       <div class="header-actions">
         <button class="btn ghost" id="contrastToggle" type="button" aria-pressed="false">High contrast</button>
@@ -40,6 +41,7 @@
           <div class="hero__actions">
             <a class="btn primary" href="#planner">Open planner</a>
             <button class="btn outline" id="demoButton" type="button">Load demo routine</button>
+            <a class="btn ghost" href="library.html">Resource hub</a>
           </div>
         </div>
         <figure class="hero__media">

--- a/library.html
+++ b/library.html
@@ -1,0 +1,154 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ShagWekker · Resource library</title>
+  <link rel="stylesheet" href="style.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700&display=swap" rel="stylesheet" />
+</head>
+<body>
+  <div class="page">
+    <header class="site-header" id="top">
+      <div class="brand" aria-label="ShagWekker">
+        <img src="assets/shag.png" alt="Placeholder logo illustration" class="brand__mark" />
+        <div class="brand__text">
+          <span class="brand__name">ShagWekker</span>
+          <span class="brand__tag">Je kan nooit genoeg Shag roken.</span>
+        </div>
+      </div>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="index.html#hero">Home</a>
+        <a href="index.html#planner">Planner</a>
+        <a href="index.html#customize">Customize</a>
+        <a href="index.html#insights">Insights</a>
+        <a href="library.html" aria-current="page">Downloads</a>
+      </nav>
+      <div class="header-actions">
+        <button class="btn ghost" id="contrastToggle" type="button" aria-pressed="false">High contrast</button>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero library-hero" id="hero">
+        <div class="hero__content">
+          <p class="hero__eyebrow">Altijd binnen handbereik</p>
+          <h1 class="hero__title">Resource library.</h1>
+          <p class="hero__lead">
+            Vind hier je toekomstige sjekkie-hand-outs, gidsen en templates. Elk kaartje linkt naar een bestand in je
+            <code>/files</code>-map zodat je ze later kunt delen of downloaden.
+          </p>
+          <div class="hero__actions">
+            <a class="btn primary" href="#downloads">Browse downloads</a>
+            <a class="btn ghost" href="index.html#planner">Back to planner</a>
+          </div>
+        </div>
+        <figure class="hero__media">
+          <img src="assets/dashboard-placeholder.svg" alt="Resource preview illustration" loading="lazy" />
+          <figcaption>Vervang de afbeelding met je eigen library visual in <code>/assets</code>.</figcaption>
+        </figure>
+      </section>
+
+      <section class="resource-section" id="downloads" aria-labelledby="downloads-heading">
+        <header class="section-header">
+          <div>
+            <p class="section-header__eyebrow">Downloads</p>
+            <h2 id="downloads-heading">Kant-en-klare sjekkie content</h2>
+          </div>
+          <p class="section-header__hint">Plaats je bestanden in de map <code>/files</code> en update de bestandsnamen wanneer je ze klaar hebt.</p>
+        </header>
+
+        <div class="resource-grid" role="list">
+          <article class="resource-card" role="listitem">
+            <span class="resource-card__badge">PDF</span>
+            <h3 class="resource-card__title">Ochtendritueel checklist</h3>
+            <p class="resource-card__meta">Start je dag met een rookplan dat werkt.</p>
+            <div class="resource-card__actions">
+              <a class="btn download" href="files/ochtendritueel-checklist.pdf">Open bestand</a>
+            </div>
+          </article>
+
+          <article class="resource-card" role="listitem">
+            <span class="resource-card__badge">DOCX</span>
+            <h3 class="resource-card__title">Nicotine intake tracker</h3>
+            <p class="resource-card__meta">Log elke shag met een eenvoudig invulsjabloon.</p>
+            <div class="resource-card__actions">
+              <a class="btn download" href="files/nicotine-intake-tracker.docx">Open bestand</a>
+            </div>
+          </article>
+
+          <article class="resource-card" role="listitem">
+            <span class="resource-card__badge">XLSX</span>
+            <h3 class="resource-card__title">Voorraad planner</h3>
+            <p class="resource-card__meta">Houd bij wanneer je nieuwe shag moet inslaan.</p>
+            <div class="resource-card__actions">
+              <a class="btn download" href="files/voorraad-planner.xlsx">Open bestand</a>
+            </div>
+          </article>
+
+          <article class="resource-card" role="listitem">
+            <span class="resource-card__badge">PDF</span>
+            <h3 class="resource-card__title">Rookpauze poster</h3>
+            <p class="resource-card__meta">Hang een poster op met jouw beste pauzetijden.</p>
+            <div class="resource-card__actions">
+              <a class="btn download" href="files/rookpauze-poster.pdf">Open bestand</a>
+            </div>
+          </article>
+
+          <article class="resource-card" role="listitem">
+            <span class="resource-card__badge">ZIP</span>
+            <h3 class="resource-card__title">Sjabloon pakket</h3>
+            <p class="resource-card__meta">Alle wekker assets gebundeld voor snelle installatie.</p>
+            <div class="resource-card__actions">
+              <a class="btn download" href="files/sjabloon-pakket.zip">Open bestand</a>
+            </div>
+          </article>
+
+          <article class="resource-card" role="listitem">
+            <span class="resource-card__badge">MP3</span>
+            <h3 class="resource-card__title">Wake-up jingle</h3>
+            <p class="resource-card__meta">Voeg een iconische tune toe aan je shagmoment.</p>
+            <div class="resource-card__actions">
+              <a class="btn download" href="files/wakeup-jingle.mp3">Open bestand</a>
+            </div>
+          </article>
+        </div>
+      </section>
+
+      <section class="resource-section resource-section--secondary" aria-labelledby="sharing-heading">
+        <header class="section-header">
+          <div>
+            <p class="section-header__eyebrow">Tips</p>
+            <h2 id="sharing-heading">Bestanden klaarzetten</h2>
+          </div>
+          <p class="section-header__hint">Vervang de bestandsnamen zodra je echte documenten hebt. De knoppen blijven automatisch werken.</p>
+        </header>
+
+        <div class="resource-guidance">
+          <article class="resource-note">
+            <h3>1. Voeg bestanden toe</h3>
+            <p>Plaats je documenten in de map <code>/files</code>. Maak eventueel submappen aan om alles georganiseerd te houden.</p>
+          </article>
+          <article class="resource-note">
+            <h3>2. Update labels</h3>
+            <p>Pas de titels aan zodat gebruikers begrijpen wat ze openen. Je kunt kaarten dupliceren voor extra downloads.</p>
+          </article>
+          <article class="resource-note">
+            <h3>3. Deel de link</h3>
+            <p>Verwijs gebruikers via deze pagina. Ze kunnen de downloads direct openen of opslaan voor later.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>&copy; <span id="footerYear"></span> ShagWekker. Shag kun je helaas niet eten, maar wel lekker roken.</p>
+      <a class="back-to-top" href="#top">Back to top</a>
+    </footer>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -419,18 +419,52 @@ function setEditingState(event) {
 }
 
 (function init() {
+  const footerYear = document.getElementById("footerYear");
+  if (footerYear) {
+    footerYear.textContent = new Date().getFullYear();
+  }
+
+  const contrastToggle = document.getElementById("contrastToggle");
+  if (contrastToggle) {
+    contrastToggle.addEventListener("click", () => {
+      const isActive = document.body.classList.toggle("high-contrast");
+      contrastToggle.setAttribute("aria-pressed", String(isActive));
+      contrastToggle.textContent = isActive ? "Default contrast" : "High contrast";
+    });
+  }
+
+  const accentControl = document.getElementById("accentControl");
+  if (accentControl) {
+    setAccentColor(accentControl.value);
+    accentControl.addEventListener("input", event => {
+      setAccentColor(event.target.value);
+    });
+  }
+
   const defaultBoard = document.getElementById("defaultBoard");
   const customBoard = document.getElementById("customBoard");
   const timelineList = document.getElementById("timelineList");
   const customEmptyState = document.getElementById("customEmptyState");
-  const accentControl = document.getElementById("accentControl");
-  const contrastToggle = document.getElementById("contrastToggle");
   const precisionToggle = document.getElementById("precisionToggle");
   const demoButton = document.getElementById("demoButton");
   const clearCustom = document.getElementById("clearCustom");
   const cancelEdit = document.getElementById("cancelEdit");
   const createEventForm = document.getElementById("createEventForm");
-  const footerYear = document.getElementById("footerYear");
+
+  const plannerElementsReady =
+    defaultBoard &&
+    customBoard &&
+    timelineList &&
+    customEmptyState &&
+    precisionToggle &&
+    demoButton &&
+    clearCustom &&
+    cancelEdit &&
+    createEventForm;
+
+  if (!plannerElementsReady) {
+    return;
+  }
 
   let customEvents = loadCustomEvents();
   let compactMode = false;
@@ -443,20 +477,6 @@ function setEditingState(event) {
   };
 
   renderAll();
-
-  footerYear.textContent = new Date().getFullYear();
-
-  setAccentColor(accentControl.value);
-
-  accentControl.addEventListener("input", event => {
-    setAccentColor(event.target.value);
-  });
-
-  contrastToggle.addEventListener("click", () => {
-    const isActive = document.body.classList.toggle("high-contrast");
-    contrastToggle.setAttribute("aria-pressed", String(isActive));
-    contrastToggle.textContent = isActive ? "Default contrast" : "High contrast";
-  });
 
   precisionToggle.addEventListener("click", () => {
     compactMode = !compactMode;

--- a/style.css
+++ b/style.css
@@ -133,6 +133,14 @@ main {
   color: var(--accent);
 }
 
+.site-nav a[aria-current="page"] {
+  color: var(--accent);
+}
+
+.site-nav a[aria-current="page"]::after {
+  transform: scaleX(1);
+}
+
 .site-nav a:focus-visible::after,
 .site-nav a:hover::after {
   transform: scaleX(1);
@@ -856,6 +864,135 @@ button {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
   gap: clamp(1rem, 2.4vw, 1.75rem);
+}
+
+.resource-section {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow-xl);
+  padding: clamp(1.8rem, 4vw, 2.6rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2rem);
+}
+
+.resource-section--secondary {
+  background: linear-gradient(165deg, rgba(16, 24, 52, 0.92), rgba(8, 15, 34, 0.92));
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.resource-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: var(--grid-gap);
+}
+
+.resource-card {
+  position: relative;
+  padding: clamp(1.4rem, 2.6vw, 1.8rem);
+  border-radius: var(--radius-lg);
+  background: radial-gradient(circle at top right, rgba(106, 162, 255, 0.18), transparent 60%), var(--surface-strong);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow-md);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition);
+  isolation: isolate;
+}
+
+.resource-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 2px solid transparent;
+  transition: border-color var(--transition);
+  pointer-events: none;
+}
+
+.resource-card:hover,
+.resource-card:focus-within {
+  transform: translateY(-6px);
+  box-shadow: 0 28px 60px rgba(0, 0, 0, 0.42);
+}
+
+.resource-card:hover::after,
+.resource-card:focus-within::after {
+  border-color: rgba(106, 162, 255, 0.4);
+}
+
+.resource-card__badge {
+  align-self: flex-start;
+  padding: 0.3rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.12);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.resource-card__title {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.resource-card__meta {
+  margin: 0;
+  color: var(--muted);
+}
+
+.resource-card__actions {
+  margin-top: auto;
+}
+
+.btn.download {
+  background: linear-gradient(130deg, rgba(106, 162, 255, 0.95), rgba(170, 118, 255, 0.95));
+  color: #050914;
+  box-shadow: 0 18px 38px rgba(106, 162, 255, 0.45);
+}
+
+.btn.download:hover,
+.btn.download:focus-visible {
+  transform: translateY(-3px);
+  box-shadow: 0 24px 46px rgba(106, 162, 255, 0.55);
+}
+
+.resource-guidance {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--grid-gap);
+}
+
+.resource-note {
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-md);
+  padding: clamp(1.1rem, 2vw, 1.6rem);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow-md);
+}
+
+.resource-note h3 {
+  margin-top: 0;
+  margin-bottom: 0.4rem;
+  font-size: 1.1rem;
+}
+
+.resource-note p {
+  margin: 0;
+  color: var(--muted);
+}
+
+@media (max-width: 720px) {
+  .resource-card {
+    padding: 1.2rem;
+  }
+
+  .resource-note {
+    padding: 1rem;
+  }
 }
 
 .insight-tile {


### PR DESCRIPTION
## Summary
- add a dedicated library.html page that mirrors the main styling and showcases placeholder download cards linked to the files/ directory
- extend global styles with resource card and navigation active-state treatments plus gradient download buttons
- update navigation and hero actions on the home page and harden script.js so shared UI controls work on both pages

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d25341a4e48325b8c1680b0528facf