### PR TITLE
Refine audio lounge volume slider enclosure

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,26 +275,17 @@
           </p>
         </header>
         <div class="audio-lounge__layout">
-          <div class="audio-lounge__visual" aria-hidden="true">
-            <div class="audio-visualizer">
-              <span class="audio-visualizer__bar" data-visual-bar style="--bar-index: 0"></span>
-              <span class="audio-visualizer__bar" data-visual-bar style="--bar-index: 1"></span>
-              <span class="audio-visualizer__bar" data-visual-bar style="--bar-index: 2"></span>
-              <span class="audio-visualizer__bar" data-visual-bar style="--bar-index: 3"></span>
-              <span class="audio-visualizer__bar" data-visual-bar style="--bar-index: 4"></span>
-              <span class="audio-visualizer__bar" data-visual-bar style="--bar-index: 5"></span>
-              <span class="audio-visualizer__bar" data-visual-bar style="--bar-index: 6"></span>
-              <span class="audio-visualizer__bar" data-visual-bar style="--bar-index: 7"></span>
-              <span class="audio-visualizer__bar" data-visual-bar style="--bar-index: 8"></span>
-            </div>
-            <p class="audio-lounge__motto">Laat de klanken je shagmoment timen.</p>
-          </div>
           <div class="audio-player" data-audio-player>
-            <p class="audio-player__status" data-audio-status>Vaste playlist wordt geladen...</p>
-            <p class="audio-player__empty" data-audio-empty hidden>
-              Voeg je bestanden toe aan de <code>audio/</code>-map en werk de vaste lijst bij in
-              <code>script.js</code> of via <code>window.SHAG_AUDIO_TRACKS</code> in een eigen script.
-            </p>
+            <header class="audio-player__headline">
+              <div>
+                <p class="audio-player__status" data-audio-status>Vaste playlist wordt geladen...</p>
+                <p class="audio-player__empty" data-audio-empty hidden>
+                  Voeg je bestanden toe aan de <code>audio/</code>-map en werk de vaste lijst bij in
+                  <code>script.js</code> of via <code>window.SHAG_AUDIO_TRACKS</code> in een eigen script.
+                </p>
+              </div>
+              <span class="audio-player__signal" aria-hidden="true"></span>
+            </header>
             <label class="audio-player__label" for="audioTrackSelect">Audiobibliotheek</label>
             <div class="audio-player__select">
               <select id="audioTrackSelect" name="audioTrack" data-audio-select disabled>
@@ -332,19 +323,47 @@
               </a>
             </div>
             <div class="audio-player__progress">
-              <span class="audio-player__time" data-audio-current>0:00</span>
-              <input
-                type="range"
-                min="0"
-                max="1000"
-                value="0"
-                step="1"
-                data-audio-progress
-                disabled
-                aria-label="Spoel door de track"
-              />
-              <span class="audio-player__time" data-audio-total>0:00</span>
+              <span class="audio-player__time audio-player__time--current" data-audio-current>0:00</span>
+              <div class="audio-player__progress-track">
+                <input
+                  type="range"
+                  min="0"
+                  max="1000"
+                  value="0"
+                  step="1"
+                  data-audio-progress
+                  disabled
+                  aria-label="Spoel door de track"
+                />
+              </div>
+              <div class="audio-player__volume">
+                <svg class="audio-player__volume-icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path
+                    d="M5.5 9.5a1 1 0 0 1 1-1H9l2.9-2.32A1 1 0 0 1 13 7v10a1 1 0 0 1-1.58.81L9 15.5H6.5a1 1 0 0 1-1-1Z"
+                  />
+                  <path
+                    d="M16.5 8.5a1 1 0 0 0-1.41 1.42 2.5 2.5 0 0 1 0 3.54A1 1 0 1 0 16.5 14.9a4.5 4.5 0 0 0 0-6.4Z"
+                  />
+                  <path
+                    d="M18.91 6.09a1 1 0 0 0-1.42 1.42 5.5 5.5 0 0 1 0 7.78 1 1 0 0 0 1.42 1.42 7.5 7.5 0 0 0 0-10.62Z"
+                  />
+                </svg>
+                <div class="audio-player__volume-box">
+                  <input
+                    class="audio-player__volume-slider"
+                    type="range"
+                    min="0"
+                    max="100"
+                    value="80"
+                    step="1"
+                    data-audio-volume
+                    aria-label="Volume"
+                  />
+                </div>
+              </div>
+              <span class="audio-player__time audio-player__time--total" data-audio-total>0:00</span>
             </div>
+            <p class="audio-player__motto">Laat de klanken je shagmoment timen.</p>
           </div>
         </div>
       </section>

--- a/script.js
+++ b/script.js
@@ -230,6 +230,8 @@ function initAudioPlayer() {
   const currentTimeEl = playerEl.querySelector("[data-audio-current]");
   const totalTimeEl = playerEl.querySelector("[data-audio-total]");
   const downloadLink = playerEl.querySelector("[data-audio-download]");
+  const volumeInput = playerEl.querySelector("[data-audio-volume]");
+  const volumeBox = playerEl.querySelector(".audio-player__volume-box");
 
   if (
     !selectEl ||
@@ -248,6 +250,8 @@ function initAudioPlayer() {
 
   const audio = new Audio();
   audio.preload = "auto";
+  const DEFAULT_VOLUME = 0.8;
+  audio.volume = DEFAULT_VOLUME;
 
   let tracks = [];
   let activeTrackIndex = -1;
@@ -255,6 +259,17 @@ function initAudioPlayer() {
 
   const setStatus = message => {
     statusEl.textContent = message;
+  };
+
+  const applyVolumeVisual = ratio => {
+    if (!volumeInput) {
+      return;
+    }
+    const clamped = Math.max(0, Math.min(1, ratio));
+    volumeInput.style.setProperty("--audio-volume", `${Math.round(clamped * 100)}%`);
+    if (volumeBox) {
+      volumeBox.style.setProperty("--audio-volume", `${Math.round(clamped * 100)}%`);
+    }
   };
 
   const resetProgress = () => {
@@ -372,6 +387,24 @@ function initAudioPlayer() {
   resetProgress();
   updateDownloadLink(null);
   setStatus("Vaste playlist wordt geladen...");
+
+  if (volumeInput) {
+    const initialValue = Number(volumeInput.value);
+    const normalized = Number.isFinite(initialValue) ? Math.max(0, Math.min(100, initialValue)) / 100 : DEFAULT_VOLUME;
+    audio.volume = normalized;
+    volumeInput.value = String(Math.round(normalized * 100));
+    applyVolumeVisual(normalized);
+
+    const handleVolumeInput = event => {
+      const value = Number(event.target.value);
+      const ratio = Number.isFinite(value) ? Math.max(0, Math.min(100, value)) / 100 : 0;
+      audio.volume = ratio;
+      applyVolumeVisual(ratio);
+    };
+
+    volumeInput.addEventListener("input", handleVolumeInput);
+    volumeInput.addEventListener("change", handleVolumeInput);
+  }
 
   discoverAudioTracks()
     .then(foundTracks => {

--- a/style.css
+++ b/style.css
@@ -1242,70 +1242,39 @@ button {
 
 .audio-lounge__layout {
   position: relative;
-  z-index: 1;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(280px, 1.1fr);
-  gap: clamp(1.5rem, 3vw, 2.5rem);
-  align-items: stretch;
-}
-
-.audio-lounge__visual {
   display: flex;
-  flex-direction: column;
   justify-content: center;
-  align-items: center;
-  gap: clamp(1rem, 2vw, 1.6rem);
-  padding: clamp(1.6rem, 3vw, 2.4rem);
+  padding: clamp(2rem, 4vw, 3.5rem);
   border-radius: var(--radius-lg);
-  background: linear-gradient(160deg, rgba(8, 14, 38, 0.6), rgba(12, 24, 58, 0.88));
+  background: linear-gradient(140deg, rgba(8, 14, 38, 0.72), rgba(12, 24, 58, 0.88));
   border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: inset 0 0 36px rgba(3, 7, 18, 0.55);
-  min-height: 240px;
+  box-shadow: var(--shadow-xl);
+  overflow: hidden;
 }
 
-.audio-lounge__motto {
-  margin: 0;
-  font-size: 0.95rem;
-  color: var(--muted);
-  text-align: center;
-  max-width: 28ch;
+.audio-lounge__layout::before {
+  content: "";
+  position: absolute;
+  inset: -15% -12% 35% 45%;
+  background: radial-gradient(circle at 85% 15%, rgba(106, 162, 255, 0.3) 0%, transparent 70%);
+  background: radial-gradient(circle at 85% 15%, color-mix(in srgb, var(--accent) 55%, transparent) 0%, transparent 70%);
+  opacity: 0.65;
+  pointer-events: none;
+  transition: opacity var(--transition), transform var(--transition);
 }
 
-.audio-visualizer {
-  width: min(100%, 360px);
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: clamp(0.5rem, 2vw, 0.9rem);
-  height: 140px;
-  padding-inline: clamp(0.5rem, 2vw, 1rem);
+.audio-lounge__layout::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.05), transparent 55%);
+  pointer-events: none;
+  opacity: 0.45;
 }
 
-.audio-visualizer__bar {
-  flex: 1;
-  min-width: 8px;
-  border-radius: 999px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.55), rgba(106, 162, 255, 0.85));
-  opacity: 0.6;
-  transform-origin: bottom;
-  animation: audioPulse calc(1.4s + var(--bar-index) * 0.08s) ease-in-out infinite;
-  animation-play-state: paused;
-  filter: drop-shadow(0 12px 24px rgba(10, 18, 45, 0.45));
-}
-
-.audio-lounge--playing .audio-visualizer__bar {
-  animation-play-state: running;
-  opacity: 0.95;
-}
-
-@keyframes audioPulse {
-  0%,
-  100% {
-    transform: scaleY(0.25);
-  }
-  50% {
-    transform: scaleY(1);
-  }
+.audio-lounge--playing .audio-lounge__layout::before {
+  opacity: 0.85;
+  transform: scale(1.05);
 }
 
 .audio-player {
@@ -1313,29 +1282,80 @@ button {
   z-index: 1;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
-  padding: clamp(1.6rem, 3vw, 2.4rem);
-  border-radius: var(--radius-lg);
-  background: linear-gradient(160deg, rgba(7, 10, 32, 0.82), rgba(9, 18, 42, 0.95));
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  box-shadow: var(--shadow-xl);
+  gap: 1.5rem;
+  width: min(100%, 760px);
+  padding: clamp(1.8rem, 4vw, 2.8rem);
+  border-radius: calc(var(--radius-lg) - 6px);
+  background: linear-gradient(160deg, rgba(5, 10, 28, 0.94), rgba(9, 18, 46, 0.88));
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  box-shadow: 0 28px 60px rgba(5, 10, 30, 0.45), 0 0 0 1px rgba(255, 255, 255, 0.06),
+    0 26px 60px -18px var(--accent);
   backdrop-filter: blur(18px);
   transition: border-color var(--transition), box-shadow var(--transition);
+  --glow-color: rgba(106, 162, 255, 0.35);
+  --glow-color: color-mix(in srgb, var(--accent) 40%, transparent);
+  --signal-color: rgba(106, 162, 255, 0.45);
+  --signal-color: color-mix(in srgb, var(--accent) 60%, transparent);
+}
+
+.audio-player::before {
+  content: "";
+  position: absolute;
+  inset: -32% -32% auto auto;
+  width: clamp(220px, 36vw, 320px);
+  aspect-ratio: 1;
+  background: radial-gradient(circle, rgba(106, 162, 255, 0.25) 0%, transparent 70%);
+  background: radial-gradient(circle, var(--glow-color) 0%, transparent 70%);
+  pointer-events: none;
+  opacity: 0.65;
+  transform: translate3d(18%, -18%, 0);
+  transition: transform var(--transition), opacity var(--transition);
+}
+
+.audio-player::after {
+  content: "";
+  position: absolute;
+  inset: auto -30% -50% -30%;
+  height: clamp(140px, 20vw, 220px);
+  background: radial-gradient(circle, rgba(106, 162, 255, 0.18) 0%, transparent 75%);
+  background: radial-gradient(circle, var(--glow-color) 0%, transparent 75%);
+  pointer-events: none;
+  opacity: 0.4;
+  transition: opacity var(--transition), transform var(--transition);
 }
 
 .audio-player:hover {
   border-color: rgba(255, 255, 255, 0.2);
-  box-shadow: 0 26px 60px -24px rgba(5, 12, 32, 0.9);
+  border-color: color-mix(in srgb, var(--accent) 40%, rgba(255, 255, 255, 0.4));
+  box-shadow: 0 30px 70px rgba(5, 10, 30, 0.55), 0 0 0 1px rgba(255, 255, 255, 0.08),
+    0 30px 70px -16px var(--accent);
+}
+
+.audio-player.is-playing::before {
+  opacity: 0.85;
+  transform: translate3d(12%, -16%, 0) scale(1.05);
+}
+
+.audio-player.is-playing::after {
+  opacity: 0.55;
+  transform: translate3d(0, -6%, 0) scale(1.05);
+}
+
+.audio-player__headline {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.25rem;
 }
 
 .audio-player__status {
   margin: 0;
-  font-size: 0.9rem;
+  font-size: 0.95rem;
   color: var(--muted);
 }
 
 .audio-player__empty {
-  margin: 0;
+  margin: 0.35rem 0 0;
   font-size: 0.85rem;
   color: var(--muted);
   background: rgba(255, 255, 255, 0.05);
@@ -1349,6 +1369,20 @@ button {
   letter-spacing: 0.02em;
 }
 
+.audio-player__signal {
+  flex: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 0 var(--signal-color);
+  transition: transform var(--transition);
+}
+
+.audio-player.is-playing .audio-player__signal {
+  animation: audioSignal 1.8s ease-in-out infinite;
+}
+
 .audio-player__select {
   position: relative;
   display: grid;
@@ -1357,19 +1391,25 @@ button {
 
 .audio-player__select select {
   appearance: none;
-  background: rgba(5, 12, 32, 0.7);
+  background: rgba(5, 12, 32, 0.75);
   border: 1px solid rgba(255, 255, 255, 0.15);
   border-radius: var(--radius-sm);
   color: inherit;
-  padding: 0.75rem 3rem 0.75rem 1rem;
+  padding: 0.85rem 3rem 0.85rem 1rem;
   font: inherit;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
   transition: border-color var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.audio-player__select select:hover {
+  border-color: rgba(255, 255, 255, 0.32);
 }
 
 .audio-player__select select:focus-visible {
   outline: none;
   border-color: var(--accent);
   box-shadow: 0 0 0 4px rgba(106, 162, 255, 0.25);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 35%, transparent);
 }
 
 .audio-player__select select:disabled {
@@ -1380,13 +1420,22 @@ button {
 .audio-player__select-caret {
   position: absolute;
   right: 1rem;
-  width: 0.75rem;
-  height: 0.75rem;
-  border-right: 2px solid currentColor;
-  border-bottom: 2px solid currentColor;
-  transform: rotate(45deg);
   pointer-events: none;
-  opacity: 0.65;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+  color: var(--muted);
+}
+
+.audio-player__select-caret::after {
+  content: "";
+  width: 0;
+  height: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 6px solid currentColor;
 }
 
 .audio-player__controls {
@@ -1413,7 +1462,8 @@ button {
 .audio-player__control:hover {
   transform: translateY(-2px);
   border-color: rgba(255, 255, 255, 0.35);
-  background: color-mix(in srgb, var(--accent) 28%, rgba(255, 255, 255, 0.12));
+  background: rgba(255, 255, 255, 0.18);
+  background: color-mix(in srgb, var(--accent) 28%, rgba(255, 255, 255, 0.18));
 }
 
 .audio-player__control:active {
@@ -1431,14 +1481,19 @@ button {
   padding: 0.6rem 0.9rem;
   border-radius: var(--radius-sm);
   border-style: dashed;
+  border-color: rgba(255, 255, 255, 0.28);
   background: rgba(255, 255, 255, 0.06);
   font-size: 0.85rem;
   text-decoration: none;
   color: inherit;
+  transition: background var(--transition), border-color var(--transition);
 }
 
 .audio-player__control--ghost:hover {
+  border-color: rgba(255, 255, 255, 0.28);
+  border-color: color-mix(in srgb, var(--accent) 45%, rgba(255, 255, 255, 0.35));
   background: rgba(255, 255, 255, 0.12);
+  background: color-mix(in srgb, var(--accent) 30%, rgba(255, 255, 255, 0.12));
 }
 
 .audio-player__control--ghost:focus-visible {
@@ -1465,9 +1520,10 @@ button {
 
 .audio-player__progress {
   display: grid;
-  grid-template-columns: auto 1fr auto;
+  grid-template-columns: auto 1fr auto auto;
   align-items: center;
-  gap: 0.75rem;
+  gap: 1.25rem;
+  grid-template-areas: "current track volume total";
 }
 
 .audio-player__time {
@@ -1476,24 +1532,59 @@ button {
   color: var(--muted);
 }
 
-.audio-player__progress input[type="range"] {
-  appearance: none;
-  width: 100%;
-  height: 6px;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.16);
-  outline: none;
+.audio-player__time--current {
+  grid-area: current;
 }
 
-.audio-player__progress input[type="range"]:disabled {
+.audio-player__time--total {
+  grid-area: total;
+}
+
+.audio-player__progress-track {
+  grid-area: track;
+  display: flex;
+  align-items: center;
+  position: relative;
+}
+
+.audio-player__progress-track input[type="range"] {
+  --audio-progress: 0%;
+  appearance: none;
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.35);
+  outline: none;
+  cursor: pointer;
+}
+
+.audio-player__progress-track input[type="range"]:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }
 
-.audio-player__progress input[type="range"]::-webkit-slider-thumb {
+.audio-player__progress-track input[type="range"]:focus-visible {
+  box-shadow: 0 0 0 4px rgba(106, 162, 255, 0.22), inset 0 1px 4px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 30%, transparent), inset 0 1px 4px rgba(0, 0, 0, 0.35);
+}
+
+.audio-player__progress-track input[type="range"]::-webkit-slider-thumb {
   appearance: none;
-  width: 16px;
-  height: 16px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid rgba(5, 10, 25, 0.6);
+  box-shadow: 0 6px 16px rgba(106, 162, 255, 0.45);
+  cursor: pointer;
+  margin-top: calc((8px - 18px) / 2);
+}
+
+.audio-player__progress-track input[type="range"]::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
   border-radius: 50%;
   background: var(--accent);
   border: 2px solid rgba(5, 10, 25, 0.6);
@@ -1501,9 +1592,133 @@ button {
   cursor: pointer;
 }
 
-.audio-player__progress input[type="range"]::-moz-range-thumb {
-  width: 16px;
-  height: 16px;
+.audio-player__progress-track input[type="range"]::-webkit-slider-runnable-track {
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--accent) var(--audio-progress, 0%), rgba(255, 255, 255, 0.12) var(--audio-progress, 0%));
+  height: 8px;
+}
+
+.audio-player__progress-track input[type="range"]::-moz-range-track {
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--accent) var(--audio-progress, 0%), rgba(255, 255, 255, 0.12) var(--audio-progress, 0%));
+  height: 8px;
+}
+
+.audio-player__volume {
+  grid-area: volume;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.85rem;
+  padding-inline: 0.5rem;
+}
+
+.audio-player__volume-icon {
+  width: 1.1rem;
+  height: 1.1rem;
+  fill: currentColor;
+  opacity: 0.8;
+}
+
+.audio-player__volume-box {
+  --volume-length: clamp(110px, 17vh, 140px);
+  --audio-volume: 80%;
+  position: relative;
+  width: clamp(64px, 8vw, 82px);
+  padding: 1rem 0.85rem;
+  min-height: calc(var(--volume-length) + 1.6rem);
+  border-radius: calc(var(--radius-md) - 4px);
+  background: linear-gradient(210deg, rgba(255, 255, 255, 0.16) 0%, rgba(8, 14, 32, 0.9) 100%);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12), 0 18px 38px rgba(5, 10, 25, 0.45);
+  overflow: hidden;
+  transition: box-shadow var(--transition), transform var(--transition);
+}
+
+.audio-player__volume-box::before {
+  content: "";
+  position: absolute;
+  inset: 6px;
+  border-radius: calc(var(--radius-md) - 10px);
+  background: linear-gradient(
+    0deg,
+    color-mix(in srgb, var(--accent) 58%, rgba(255, 255, 255, 0.12)) 0%,
+    color-mix(in srgb, var(--accent) 58%, rgba(255, 255, 255, 0.12)) var(--audio-volume, 80%),
+    rgba(9, 16, 36, 0.82) calc(var(--audio-volume, 80%) + 1%),
+    rgba(9, 16, 36, 0.82) 100%
+  );
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12);
+  pointer-events: none;
+}
+
+.audio-player__volume-box::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: linear-gradient(200deg, color-mix(in srgb, var(--accent) 40%, transparent) 0%, transparent 65%);
+  opacity: 0.4;
+  pointer-events: none;
+  transition: opacity var(--transition);
+}
+
+.audio-player__volume-box:hover {
+  transform: translateY(-2px);
+}
+
+.audio-player__volume-box:hover::after {
+  opacity: 0.55;
+}
+
+.audio-player__volume-box:focus-within {
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.16), 0 22px 44px rgba(5, 10, 25, 0.55),
+    0 0 0 2px color-mix(in srgb, var(--accent) 45%, transparent);
+}
+
+.audio-player__volume-box:focus-within::after {
+  opacity: 0.65;
+}
+
+.audio-player__volume-slider {
+  --audio-volume: 80%;
+  appearance: none;
+  width: var(--volume-length);
+  height: 8px;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) rotate(-90deg);
+  transform-origin: center;
+  z-index: 1;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 1px 4px rgba(0, 0, 0, 0.35);
+  cursor: pointer;
+  outline: none;
+}
+
+.audio-player__volume-slider:focus-visible {
+  box-shadow: 0 0 0 4px rgba(106, 162, 255, 0.22), inset 0 1px 4px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--accent) 30%, transparent), inset 0 1px 4px rgba(0, 0, 0, 0.35);
+}
+
+.audio-player__volume-slider::-webkit-slider-thumb {
+  appearance: none;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: var(--accent);
+  border: 2px solid rgba(5, 10, 25, 0.6);
+  box-shadow: 0 6px 16px rgba(106, 162, 255, 0.45);
+  cursor: pointer;
+  margin-top: calc((8px - 18px) / 2);
+}
+
+.audio-player__volume-slider::-moz-range-thumb {
+  width: 18px;
+  height: 18px;
   border-radius: 50%;
   background: var(--accent);
   border: 2px solid rgba(5, 10, 25, 0.6);
@@ -1511,21 +1726,53 @@ button {
   cursor: pointer;
 }
 
-.audio-player__progress input[type="range"]::-webkit-slider-runnable-track {
+.audio-player__volume-slider::-webkit-slider-runnable-track {
   border-radius: 999px;
-  background: linear-gradient(90deg, var(--accent) var(--audio-progress, 0%), rgba(255, 255, 255, 0.12) var(--audio-progress, 0%));
-  height: 6px;
+  background: linear-gradient(90deg, var(--accent) var(--audio-volume, 0%), rgba(255, 255, 255, 0.12) var(--audio-volume, 0%));
+  height: 8px;
 }
 
-.audio-player__progress input[type="range"]::-moz-range-track {
+.audio-player__volume-slider::-moz-range-track {
   border-radius: 999px;
-  background: linear-gradient(90deg, var(--accent) var(--audio-progress, 0%), rgba(255, 255, 255, 0.12) var(--audio-progress, 0%));
-  height: 6px;
+  background: linear-gradient(90deg, var(--accent) var(--audio-volume, 0%), rgba(255, 255, 255, 0.12) var(--audio-volume, 0%));
+  height: 8px;
+}
+
+.audio-player__motto {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--muted);
+  text-align: center;
+  background: rgba(255, 255, 255, 0.04);
+  padding: 0.85rem 1.1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+@keyframes audioSignal {
+  0% {
+    transform: scale(1);
+    box-shadow: 0 0 0 0 var(--signal-color);
+  }
+  65% {
+    transform: scale(1.08);
+    box-shadow: 0 0 0 12px rgba(106, 162, 255, 0.12);
+    box-shadow: 0 0 0 12px color-mix(in srgb, var(--accent) 2%, transparent);
+  }
+  100% {
+    transform: scale(1);
+    box-shadow: 0 0 0 0 transparent;
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 0%, transparent);
+  }
 }
 
 @media (max-width: 960px) {
   .audio-lounge__layout {
-    grid-template-columns: 1fr;
+    padding: clamp(1.5rem, 5vw, 2.5rem);
+  }
+
+  .audio-player {
+    width: 100%;
   }
 
   .audio-player__controls {
@@ -1534,6 +1781,27 @@ button {
 
   .audio-player__control {
     flex: 1 0 46px;
+  }
+}
+
+@media (max-width: 720px) {
+  .audio-player__progress {
+    grid-template-columns: auto 1fr auto;
+    grid-template-areas:
+      "current track total"
+      ". volume .";
+    row-gap: 1.5rem;
+  }
+
+  .audio-player__volume {
+    flex-direction: row;
+    gap: 1rem;
+  }
+
+  .audio-player__volume-box {
+    --volume-length: clamp(136px, 46vw, 200px);
+    width: clamp(72px, 20vw, 96px);
+    padding: 1rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- replace the split audio lounge layout with a single accent-driven player that contains the status header, controls, and motto
- restyle the player and progress area to showcase the site accent colour, add a vertical volume slider, and update responsive behaviour
- hook the new volume control into the audio player script with default volume handling and live visual updates
- nest the volume slider inside an accent-highlighted housing that harmonises with the player and mirrors the live volume level

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3056b8a8c83258983834978a25b0f