### PR TITLE
Add gallery modal lightbox with animated captions

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -78,6 +78,12 @@
       const galleryContainer = document.querySelector("[data-gallery]");
       if (!galleryContainer) return;
 
+      const modal = createModal();
+      const modalImage = modal.querySelector("[data-gallery-modal-image]");
+      const modalTitle = modal.querySelector("[data-gallery-modal-title]");
+      const modalDescription = modal.querySelector("[data-gallery-modal-description]");
+      const modalCaption = modal.querySelector(".gallery-modal__caption");
+
       /**
        * Gallery-onderhoud tutorial (voor de websitebeheerder):
        * 1. Voeg je afbeeldingen toe aan de map /assets/gallery/ en onthoud de bestandsnamen.
@@ -139,6 +145,14 @@
           const image = document.createElement("img");
           image.src = item.src;
           image.alt = item.alt || item.title || `Gallery afbeelding ${index + 1}`;
+          image.addEventListener("click", () => openModal(item));
+          image.tabIndex = 0;
+          image.addEventListener("keydown", (event) => {
+            if (event.key === "Enter" || event.key === " ") {
+              event.preventDefault();
+              openModal(item);
+            }
+          });
           figure.appendChild(image);
         } else {
           const placeholder = document.createElement("div");
@@ -163,6 +177,77 @@
 
         galleryContainer.appendChild(card);
       });
+
+      function createModal() {
+        const modalEl = document.createElement("div");
+        modalEl.className = "gallery-modal";
+        modalEl.setAttribute("aria-hidden", "true");
+
+        modalEl.innerHTML = `
+          <div class="gallery-modal__dialog" role="dialog" aria-modal="true" aria-label="Galerij detail">
+            <button class="gallery-modal__close" type="button" data-gallery-close aria-label="Sluit detail">&times;</button>
+            <img class="gallery-modal__image" data-gallery-modal-image alt="" />
+            <figcaption class="gallery-modal__caption">
+              <h3 class="gallery-modal__title" data-gallery-modal-title></h3>
+              <p class="gallery-modal__description" data-gallery-modal-description></p>
+            </figcaption>
+          </div>
+        `;
+
+        modalEl.addEventListener("click", (event) => {
+          if (event.target === modalEl) {
+            closeModal();
+          }
+        });
+
+        const closeButton = modalEl.querySelector("[data-gallery-close]");
+        closeButton.addEventListener("click", closeModal);
+
+        document.body.appendChild(modalEl);
+        return modalEl;
+      }
+
+      function openModal(item) {
+        if (!item.src) return;
+
+        modalImage.src = item.src;
+        modalImage.alt = item.alt || item.title || "";
+
+        modalTitle.textContent = item.title || "Untitled";
+
+        if (item.description) {
+          modalDescription.textContent = item.description;
+          modalDescription.hidden = false;
+        } else {
+          modalDescription.textContent = "";
+          modalDescription.hidden = true;
+        }
+
+        modal.setAttribute("aria-hidden", "false");
+        modal.classList.add("is-open");
+
+        requestAnimationFrame(() => {
+          modalCaption.classList.remove("animate-in");
+          void modalCaption.offsetWidth;
+          modalCaption.classList.add("animate-in");
+        });
+
+        document.addEventListener("keydown", handleKeyDown);
+      }
+
+      function closeModal() {
+        modal.classList.remove("is-open");
+        modal.setAttribute("aria-hidden", "true");
+        modalCaption.classList.remove("animate-in");
+        modalImage.src = "";
+        document.removeEventListener("keydown", handleKeyDown);
+      }
+
+      function handleKeyDown(event) {
+        if (event.key === "Escape") {
+          closeModal();
+        }
+      }
     })();
   </script>
 </body>

--- a/style.css
+++ b/style.css
@@ -1059,6 +1059,14 @@ button {
   border-radius: var(--radius-md);
   border: 1px solid rgba(255, 255, 255, 0.08);
   box-shadow: var(--shadow-md);
+  cursor: zoom-in;
+  transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.gallery-card__frame img:hover,
+.gallery-card__frame img:focus-visible {
+  transform: translateY(-2px) scale(1.01);
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.42);
 }
 
 .gallery-card__placeholder {
@@ -1091,6 +1099,103 @@ button {
 .gallery-card__description {
   margin: 0;
   color: var(--muted);
+}
+
+.gallery-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1.5rem, 5vw, 3rem);
+  background: rgba(2, 6, 18, 0.7);
+  backdrop-filter: blur(18px);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 220ms ease;
+  z-index: 40;
+}
+
+.gallery-modal.is-open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.gallery-modal__dialog {
+  position: relative;
+  width: min(640px, 100%);
+  display: grid;
+  gap: clamp(1.25rem, 3vw, 1.75rem);
+  padding: clamp(1.5rem, 4vw, 2.4rem);
+  border-radius: var(--radius-lg);
+  background: var(--surface-strong);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: var(--shadow-xl);
+}
+
+.gallery-modal__image {
+  width: 100%;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: var(--shadow-md);
+  object-fit: cover;
+}
+
+.gallery-modal__caption {
+  display: grid;
+  gap: 0.65rem;
+  opacity: 0;
+  transform: translateY(16px);
+}
+
+.gallery-modal__caption.animate-in {
+  animation: galleryFadeIn 360ms ease forwards;
+}
+
+.gallery-modal__title {
+  margin: 0;
+  font-size: clamp(1.4rem, 3.2vw, 1.8rem);
+  font-weight: 700;
+}
+
+.gallery-modal__description {
+  margin: 0;
+  color: var(--muted);
+}
+
+.gallery-modal__close {
+  position: absolute;
+  top: 0.85rem;
+  right: 0.85rem;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  display: grid;
+  place-items: center;
+  font-size: 1.4rem;
+  cursor: pointer;
+  transition: background var(--transition), transform var(--transition);
+}
+
+.gallery-modal__close:hover,
+.gallery-modal__close:focus-visible {
+  background: rgba(255, 255, 255, 0.16);
+  transform: scale(1.03);
+}
+
+@keyframes galleryFadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(18px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @media (max-width: 720px) {


### PR DESCRIPTION
## Summary
- add a reusable gallery modal that opens images with their metadata when cards are activated
- enhance gallery card images with keyboard support and introduce a fade-in animation for modal text
- style the modal overlay to match the existing aesthetic with blur, shadows, and hover treatments

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d43fcc338083258d9a613b7e90f1ce