### PR TITLE
Refocus nicotine teller as primary event board

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,18 +83,18 @@
         <div class="planner__primary">
           <header class="section-header">
             <div>
-              <p class="section-header__eyebrow">Standaard Landstede Shagpauzes</p>
-              <h2>Dagelijkse Kost</h2>
+              <p class="section-header__eyebrow">Uw dagelijkse nicotine overzicht</p>
+              <h2>Nicotine Teller</h2>
             </div>
             <p class="section-header__hint"><i>“Nicotine is a performance enhancing drug”</i></p>
           </header>
-          <div id="defaultBoard" class="card-grid" role="list"></div>
+          <div id="tellerBoard" class="card-grid" role="list"></div>
         </div>
         <aside class="planner__sidebar" aria-label="Upcoming timeline">
           <header class="section-header">
             <div>
-              <p class="section-header__eyebrow">What&rsquo;s on deck</p>
-              <h2>Nicotine Teller</h2>
+              <p class="section-header__eyebrow">Wat staat er op stapel</p>
+              <h2>Ritme Tijdlijn</h2>
             </div>
             <button class="btn ghost" id="precisionToggle" type="button" aria-pressed="false">Compact view</button>
           </header>


### PR DESCRIPTION
## Summary
- rename the Dagelijkse Kost planner column to Nicotine Teller and make it the primary card grid
- render both core and personal cues inside the Nicotine Teller so all cards share the same live countdown view
- update countdown/highlight logic to keep multiple card instances in sync

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4e2f909e08325b77f4a84db10ef94