### PR TITLE
Add ShagMeter page with timeline and progress meter

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -24,6 +24,7 @@
         <a href="index.html#planner">Nicotineteller</a>
         <a href="index.html#customize">Inlassen</a>
         <a href="index.html#insights">Insights</a>
+        <a href="shagmeter.html">ShagMeter</a>
         <a href="gallery.html" aria-current="page">Gallery</a>
         <a href="library.html">ShagFiles</a>
       </nav>

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
         <a href="#planner">Nicotineteller</a>
         <a href="#customize">Inlassen</a>
         <a href="#insights">Insights</a>
+        <a href="shagmeter.html">ShagMeter</a>
         <a href="gallery.html">Gallery</a>
         <a href="library.html">ShagFiles</a>
       </nav>

--- a/library.html
+++ b/library.html
@@ -24,6 +24,7 @@
         <a href="index.html#planner">Nicotineteller</a>
         <a href="index.html#customize">Inlassen</a>
         <a href="index.html#insights">Insights</a>
+        <a href="shagmeter.html">ShagMeter</a>
         <a href="gallery.html">Gallery</a>
         <a href="library.html" aria-current="page">ShagFiles</a>
       </nav>

--- a/shagmeter.html
+++ b/shagmeter.html
@@ -91,24 +91,31 @@
               </div>
             </div>
 
-            <div
-              class="shagmeter__bar"
-              role="meter"
-              aria-valuemin="0"
-              aria-valuemax="8"
-              aria-valuenow="0"
-              aria-label="ShagMeter voortgang"
-              data-shagmeter-meter
-            >
-              <div class="shagmeter__fill" data-shagmeter-fill></div>
-              <div class="shagmeter__sparkle" aria-hidden="true"></div>
+            <div class="shagmeter__display">
+              <div
+                class="shagmeter__core"
+                role="meter"
+                aria-valuemin="0"
+                aria-valuemax="8"
+                aria-valuenow="0"
+                aria-label="ShagMeter voortgang"
+                data-shagmeter-meter
+              >
+                <div class="shagmeter__pulse" aria-hidden="true"></div>
+                <div class="shagmeter__value">
+                  <span class="shagmeter__count" data-shagmeter-count>0</span>
+                  <span class="shagmeter__count-label" data-shagmeter-count-label>shaggs</span>
+                </div>
+              </div>
+              <div class="shagmeter__eruption" data-shagmeter-explosion aria-hidden="true"></div>
             </div>
 
             <p class="shagmeter__status" data-shagmeter-status>0 van 8 shaggs genoteerd.</p>
 
             <div class="shagmeter__actions">
-              <button class="btn primary shagmeter__add" type="button" data-shagmeter-add>+Shaggie</button>
-              <button class="btn ghost" type="button" data-shagmeter-reset>Reset</button>
+              <button class="shagmeter__add-btn" type="button" data-shagmeter-add aria-label="Voeg een shaggie toe">+</button>
+              <span class="shagmeter__actions-label">Shaggie</span>
+              <button class="btn ghost shagmeter__reset" type="button" data-shagmeter-reset>Reset</button>
             </div>
           </article>
         </div>

--- a/shagmeter.html
+++ b/shagmeter.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ShagWekker · ShagMeter</title>
+  <link rel="stylesheet" href="style.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700&display=swap" rel="stylesheet" />
+</head>
+<body>
+  <div class="page">
+    <header class="site-header" id="top">
+      <div class="brand" aria-label="ShagWekker">
+        <img src="assets/shag.png" alt="Placeholder logo illustration" class="brand__mark" />
+        <div class="brand__text">
+          <span class="brand__name">ShagWekker</span>
+          <span class="brand__tag">Je kan nooit genoeg Shag roken.</span>
+        </div>
+      </div>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="index.html#hero">Shag</a>
+        <a href="index.html#planner">Nicotineteller</a>
+        <a href="index.html#customize">Inlassen</a>
+        <a href="index.html#insights">Insights</a>
+        <a href="shagmeter.html" aria-current="page">ShagMeter</a>
+        <a href="gallery.html">Gallery</a>
+        <a href="library.html">ShagFiles</a>
+      </nav>
+      <div class="header-actions">
+        <button class="btn ghost" id="contrastToggle" type="button" aria-pressed="false">High contrast</button>
+      </div>
+    </header>
+
+    <main>
+      <section class="hero meter-hero" id="hero">
+        <div class="hero__content">
+          <p class="hero__eyebrow">Sla je volgende shag nooit over</p>
+          <h1 class="hero__title">ShagMeter.</h1>
+          <p class="hero__lead">
+            Hou de Nicotine Teller vibe levend op een aparte pagina. Een snelle blik geeft je direct de eerstvolgende shag cue én je dagelijkse shag-doel.
+          </p>
+          <div class="hero__actions">
+            <a class="btn primary" href="#meter">Ga naar de meter</a>
+            <a class="btn ghost" href="index.html#planner">Terug naar de planning</a>
+          </div>
+        </div>
+        <figure class="hero__media meter-hero__media">
+          <img src="assets/shag.png" alt="ShagMeter visual" loading="lazy" />
+        </figure>
+      </section>
+
+      <section class="meter-section" id="meter" data-shagmeter>
+        <header class="section-header">
+          <div>
+            <p class="section-header__eyebrow">Next up</p>
+            <h2>Jouw eerstvolgende shagmoment &amp; ShagMeter</h2>
+          </div>
+          <p class="section-header__hint">Koppelt de Nicotineteller aan een dagelijkse shag goal. Klik en vul die meter.</p>
+        </header>
+
+        <div class="meter-layout">
+          <article class="meter-card">
+            <header class="meter-card__header">
+              <h3>Volgende cue</h3>
+              <p>Direct gekloond uit de Nicotineteller.</p>
+            </header>
+            <ol class="timeline timeline--solo" data-shagmeter-timeline aria-live="polite"></ol>
+          </article>
+
+          <article class="meter-card shagmeter-card">
+            <header class="meter-card__header">
+              <h3>ShagMeter</h3>
+              <p>Tel je shaggies tot je doel bereikt is.</p>
+            </header>
+            <div class="shagmeter__goal">
+              <label for="shagmeterGoal">Dagelijkse shag goal</label>
+              <div class="shagmeter__goal-control">
+                <input
+                  id="shagmeterGoal"
+                  type="range"
+                  min="1"
+                  max="20"
+                  step="1"
+                  value="8"
+                  data-shagmeter-goal
+                  aria-label="Dagelijkse shag goal"
+                />
+                <span class="shagmeter__goal-value" data-shagmeter-goal-value>8 shaggs</span>
+              </div>
+            </div>
+
+            <div
+              class="shagmeter__bar"
+              role="meter"
+              aria-valuemin="0"
+              aria-valuemax="8"
+              aria-valuenow="0"
+              aria-label="ShagMeter voortgang"
+              data-shagmeter-meter
+            >
+              <div class="shagmeter__fill" data-shagmeter-fill></div>
+              <div class="shagmeter__sparkle" aria-hidden="true"></div>
+            </div>
+
+            <p class="shagmeter__status" data-shagmeter-status>0 van 8 shaggs genoteerd.</p>
+
+            <div class="shagmeter__actions">
+              <button class="btn primary shagmeter__add" type="button" data-shagmeter-add>+Shaggie</button>
+              <button class="btn ghost" type="button" data-shagmeter-reset>Reset</button>
+            </div>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>&copy; <span id="footerYear"></span> ShagWekker. Shag kun je helaas niet eten, maar wel lekker roken.</p>
+      <a class="back-to-top" href="#top">Back to top</a>
+    </footer>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -19,6 +19,12 @@
   --grid-gap: clamp(1rem, 2vw, 1.8rem);
 }
 
+@property --shagmeter-progress {
+  syntax: "<number>";
+  inherits: false;
+  initial-value: 0;
+}
+
 * {
   box-sizing: border-box;
 }
@@ -242,7 +248,7 @@ main {
 
 .shagmeter-card {
   position: relative;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .shagmeter-card::after {
@@ -254,12 +260,16 @@ main {
 }
 
 .shagmeter-card.is-complete {
-  box-shadow: 0 20px 50px rgba(255, 0, 70, 0.3);
+  box-shadow: 0 20px 50px rgba(255, 0, 70, 0.35);
   border-color: rgba(255, 255, 255, 0.18);
 }
 
 .shagmeter-card.is-complete .shagmeter__status {
   color: var(--success);
+}
+
+.shagmeter-card.is-exploding::after {
+  background: radial-gradient(circle, rgba(255, 0, 90, 0.22), transparent 65%);
 }
 
 .shagmeter__goal {
@@ -287,74 +297,207 @@ main {
   font-weight: 600;
 }
 
-.shagmeter__bar {
+.shagmeter__display {
   position: relative;
-  height: 26px;
-  border-radius: var(--radius-sm);
-  background: rgba(255, 255, 255, 0.08);
+  display: grid;
+  place-items: center;
+  margin: 0 auto;
+  width: min(320px, 70vw);
+}
+
+.shagmeter__core {
+  --shagmeter-progress: 0;
+  --shagmeter-progress-deg: calc(var(--shagmeter-progress) * 360deg);
+  position: relative;
+  width: 100%;
+  aspect-ratio: 1 / 1;
+  display: grid;
+  place-items: center;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 45%, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0) 60%),
+    rgba(255, 255, 255, 0.04);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08), 0 40px 90px rgba(255, 0, 90, 0.18);
   overflow: hidden;
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+  z-index: 1;
+  transition: --shagmeter-progress 0.6s ease;
 }
 
-.shagmeter__fill {
+.shagmeter__core::before {
+  content: "";
   position: absolute;
   inset: 0;
-  width: 0%;
-  background: linear-gradient(90deg, var(--accent), rgba(255, 108, 155, 0.9));
-  transition: width var(--transition);
+  border-radius: 50%;
+  background: conic-gradient(
+    from -90deg,
+    var(--accent) var(--shagmeter-progress-deg),
+    rgba(255, 255, 255, 0.08) var(--shagmeter-progress-deg)
+  );
+  filter: drop-shadow(0 0 25px rgba(255, 0, 90, 0.4));
 }
 
-.shagmeter__sparkle {
+.shagmeter__core::after {
+  content: "";
+  position: absolute;
+  inset: 14%;
+  border-radius: 50%;
+  background: var(--surface-strong);
+  box-shadow: inset 0 0 40px rgba(0, 0, 0, 0.45);
+}
+
+.shagmeter__value {
+  position: relative;
+  z-index: 2;
+  display: grid;
+  place-items: center;
+  gap: 0.25rem;
+  text-align: center;
+}
+
+.shagmeter__count {
+  font-size: clamp(2.8rem, 6vw, 3.6rem);
+  font-weight: 700;
+}
+
+.shagmeter__count-label {
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  font-size: 0.7rem;
+  color: var(--muted);
+}
+
+.shagmeter__pulse {
   position: absolute;
   inset: 0;
-  background: radial-gradient(circle at 10% 40%, rgba(255, 255, 255, 0.25), transparent 60%),
-    radial-gradient(circle at 70% 30%, rgba(255, 255, 255, 0.2), transparent 55%);
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 255, 255, 0.18), transparent 60%);
   mix-blend-mode: screen;
+  opacity: 0;
+}
+
+.shagmeter__core.is-active .shagmeter__pulse {
+  animation: shagmeter-pulse 1.6s ease-out;
+}
+
+.shagmeter__core.is-active::before {
+  animation: shagmeter-core-flash 1.6s ease-out;
+}
+
+.shagmeter__eruption {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 120%;
+  aspect-ratio: 1 / 1;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(255, 0, 90, 0.45), transparent 60%);
   pointer-events: none;
-  opacity: 0.6;
+  opacity: 0;
+  z-index: 0;
+  transform: translate(-50%, -50%) scale(0.75);
+}
+
+.shagmeter__eruption.is-active {
+  animation: shagmeter-burst 2.4s cubic-bezier(0.22, 1, 0.36, 1) forwards;
 }
 
 .shagmeter__status {
   margin: 0;
   font-size: 0.95rem;
   color: var(--muted);
+  text-align: center;
 }
 
 .shagmeter__actions {
   display: flex;
+  align-items: center;
+  gap: 1rem;
+  justify-content: center;
   flex-wrap: wrap;
-  gap: 0.75rem;
 }
 
-.shagmeter__add {
-  position: relative;
-  overflow: hidden;
-  background: linear-gradient(135deg, var(--accent), rgba(255, 120, 200, 0.95));
+.shagmeter__add-btn {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
   border: none;
-  box-shadow: 0 12px 30px rgba(255, 0, 80, 0.35);
+  display: grid;
+  place-items: center;
+  font-size: 2.2rem;
+  font-weight: 700;
+  color: #fff;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.4), transparent 55%),
+    linear-gradient(140deg, var(--accent), rgba(255, 117, 190, 0.95));
+  box-shadow: 0 20px 45px rgba(255, 0, 90, 0.38);
+  cursor: pointer;
+  transition: transform 180ms ease, box-shadow 180ms ease;
 }
 
-.shagmeter__add::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  background: linear-gradient(120deg, rgba(255, 255, 255, 0.25), transparent 60%);
-  opacity: 0;
-  transition: opacity var(--transition);
+.shagmeter__add-btn:hover,
+.shagmeter__add-btn:focus-visible {
+  transform: translateY(-4px) scale(1.05);
+  box-shadow: 0 26px 60px rgba(255, 0, 110, 0.48);
 }
 
-.shagmeter__add:hover::after,
-.shagmeter__add:focus-visible::after {
-  opacity: 1;
+.shagmeter__add-btn:disabled {
+  cursor: not-allowed;
+  filter: grayscale(0.3);
+  opacity: 0.65;
 }
 
-.shagmeter-card.is-complete .shagmeter__add {
-  box-shadow: 0 12px 30px rgba(126, 247, 161, 0.4);
-  background: linear-gradient(135deg, var(--success), rgba(180, 255, 210, 0.95));
+.shagmeter-card.is-complete .shagmeter__add-btn {
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.4), transparent 55%),
+    linear-gradient(140deg, var(--success), rgba(190, 255, 214, 0.95));
+  box-shadow: 0 26px 60px rgba(126, 247, 161, 0.45);
 }
 
-.shagmeter-card.is-complete .shagmeter__add::after {
-  background: linear-gradient(120deg, rgba(255, 255, 255, 0.3), transparent 60%);
+.shagmeter__actions-label {
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.shagmeter__reset {
+  border-radius: 999px;
+}
+
+@keyframes shagmeter-pulse {
+  0% {
+    opacity: 0.75;
+    transform: scale(1);
+  }
+  70% {
+    opacity: 0.25;
+    transform: scale(1.35);
+  }
+  100% {
+    opacity: 0;
+    transform: scale(1.6);
+  }
+}
+
+@keyframes shagmeter-core-flash {
+  0% {
+    filter: drop-shadow(0 0 25px rgba(255, 0, 110, 0.5));
+  }
+  100% {
+    filter: drop-shadow(0 0 10px rgba(255, 0, 110, 0.1));
+  }
+}
+
+@keyframes shagmeter-burst {
+  0% {
+    opacity: 0.85;
+    transform: translate(-50%, -50%) scale(1);
+  }
+  60% {
+    opacity: 0.35;
+    transform: translate(-50%, -50%) scale(6);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -50%) scale(14);
+  }
 }
 
 .hero__media figcaption {

--- a/style.css
+++ b/style.css
@@ -199,6 +199,164 @@ main {
   border-radius: var(--radius-md);
 }
 
+.meter-hero__media {
+  background: var(--surface);
+}
+
+.meter-section {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 5vw, 3rem);
+}
+
+.meter-layout {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: var(--grid-gap);
+}
+
+.meter-card {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  box-shadow: var(--shadow-md);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.meter-card__header h3 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.meter-card__header p {
+  margin: 0.35rem 0 0;
+  color: var(--muted);
+}
+
+.timeline--solo {
+  margin: 0;
+}
+
+.shagmeter-card {
+  position: relative;
+  overflow: hidden;
+}
+
+.shagmeter-card::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(140deg, rgba(255, 255, 255, 0.04), transparent 60%);
+}
+
+.shagmeter-card.is-complete {
+  box-shadow: 0 20px 50px rgba(255, 0, 70, 0.3);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
+.shagmeter-card.is-complete .shagmeter__status {
+  color: var(--success);
+}
+
+.shagmeter__goal {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.shagmeter__goal label {
+  font-weight: 600;
+}
+
+.shagmeter__goal-control {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.shagmeter__goal-control input[type="range"] {
+  flex: 1;
+  accent-color: var(--accent);
+}
+
+.shagmeter__goal-value {
+  font-weight: 600;
+}
+
+.shagmeter__bar {
+  position: relative;
+  height: 26px;
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+}
+
+.shagmeter__fill {
+  position: absolute;
+  inset: 0;
+  width: 0%;
+  background: linear-gradient(90deg, var(--accent), rgba(255, 108, 155, 0.9));
+  transition: width var(--transition);
+}
+
+.shagmeter__sparkle {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 10% 40%, rgba(255, 255, 255, 0.25), transparent 60%),
+    radial-gradient(circle at 70% 30%, rgba(255, 255, 255, 0.2), transparent 55%);
+  mix-blend-mode: screen;
+  pointer-events: none;
+  opacity: 0.6;
+}
+
+.shagmeter__status {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.shagmeter__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.shagmeter__add {
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(135deg, var(--accent), rgba(255, 120, 200, 0.95));
+  border: none;
+  box-shadow: 0 12px 30px rgba(255, 0, 80, 0.35);
+}
+
+.shagmeter__add::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.25), transparent 60%);
+  opacity: 0;
+  transition: opacity var(--transition);
+}
+
+.shagmeter__add:hover::after,
+.shagmeter__add:focus-visible::after {
+  opacity: 1;
+}
+
+.shagmeter-card.is-complete .shagmeter__add {
+  box-shadow: 0 12px 30px rgba(126, 247, 161, 0.4);
+  background: linear-gradient(135deg, var(--success), rgba(180, 255, 210, 0.95));
+}
+
+.shagmeter-card.is-complete .shagmeter__add::after {
+  background: linear-gradient(120deg, rgba(255, 255, 255, 0.3), transparent 60%);
+}
+
 .hero__media figcaption {
   font-size: 0.85rem;
   color: var(--muted);


### PR DESCRIPTION
## Summary
- add a dedicated ShagMeter page that mirrors the Nicotineteller timeline styling and introduces a goal-based shag counter
- extend the global script with ShagMeter logic that reuses stored events and persists meter progress
- update shared navigation and styling to keep the new experience consistent across the site

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5090e67788325a90a56e6878cbac9