### PR TITLE
Add hidden BomboClock easter egg

### DIFF
--- a/script.js
+++ b/script.js
@@ -61,6 +61,8 @@ const DEFAULT_ACCENT_COLOR = "#ff0000";
 const BOMBOCLOCK_ACCENT_COLOR = "#1f8a3b";
 const BOMBOCLOCK_ACTIVATION_CLICKS = 3;
 const BOMBOCLOCK_REPLACEMENTS = [
+  { pattern: /Shaggies/g, replacement: "Jonkos" },
+  { pattern: /shaggies/g, replacement: "jonkos" },
   { pattern: /ShagWekker/g, replacement: "BomboClock" },
   { pattern: /Shag/g, replacement: "Jonko" },
   { pattern: /shag/g, replacement: "jonko" }
@@ -1107,14 +1109,14 @@ function initShagMeter() {
     if (amount === 1) {
       return "shaggie";
     }
-    return "shaggs";
+    return "Shaggies";
   };
 
   const pluralizeShag = amount => {
     if (amount === 1) {
       return "1 shaggie";
     }
-    return `${amount} shaggs`;
+    return `${amount} Shaggies`;
   };
 
   const loadState = () => {
@@ -1286,6 +1288,14 @@ function initBomboClockEasterEgg() {
   let activationCount = 0;
   let textTransformed = false;
   let accentApplied = false;
+  const animationClass = "brand--bombo-hint";
+
+  const triggerHintAnimation = () => {
+    brand.classList.remove(animationClass);
+    // Force a reflow so the animation can replay on successive clicks.
+    void brand.offsetWidth;
+    brand.classList.add(animationClass);
+  };
 
   const applyReplacements = () => {
     if (textTransformed) {
@@ -1354,9 +1364,16 @@ function initBomboClockEasterEgg() {
 
   brand.addEventListener("click", () => {
     activationCount += 1;
-    applyReplacements();
+    triggerHintAnimation();
     if (activationCount >= BOMBOCLOCK_ACTIVATION_CLICKS) {
+      applyReplacements();
       applyAccent();
+    }
+  });
+
+  brand.addEventListener("animationend", event => {
+    if (event.target === brand) {
+      brand.classList.remove(animationClass);
     }
   });
 }

--- a/script.js
+++ b/script.js
@@ -58,6 +58,13 @@ const STATIC_AUDIO_REFERENCES = [
 ];
 
 const DEFAULT_ACCENT_COLOR = "#ff0000";
+const BOMBOCLOCK_ACCENT_COLOR = "#1f8a3b";
+const BOMBOCLOCK_ACTIVATION_CLICKS = 3;
+const BOMBOCLOCK_REPLACEMENTS = [
+  { pattern: /ShagWekker/g, replacement: "BomboClock" },
+  { pattern: /Shag/g, replacement: "Jonko" },
+  { pattern: /shag/g, replacement: "jonko" }
+];
 const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
 
 const PREFERENCE_KEYS = {
@@ -1270,6 +1277,90 @@ function setAccentColor(color, { persist = false } = {}) {
   }
 }
 
+function initBomboClockEasterEgg() {
+  const brand = document.querySelector(".site-header .brand");
+  if (!brand) {
+    return;
+  }
+
+  let activationCount = 0;
+  let textTransformed = false;
+  let accentApplied = false;
+
+  const applyReplacements = () => {
+    if (textTransformed) {
+      return;
+    }
+
+    const walker = document.createTreeWalker(
+      document.body,
+      NodeFilter.SHOW_TEXT,
+      {
+        acceptNode(node) {
+          return node && node.nodeValue && node.nodeValue.trim()
+            ? NodeFilter.FILTER_ACCEPT
+            : NodeFilter.FILTER_REJECT;
+        }
+      }
+    );
+
+    const transform = value =>
+      BOMBOCLOCK_REPLACEMENTS.reduce((current, replacement) => {
+        return current.replace(replacement.pattern, replacement.replacement);
+      }, value);
+
+    while (walker.nextNode()) {
+      const node = walker.currentNode;
+      const original = node.nodeValue;
+      const updated = transform(original);
+      if (updated !== original) {
+        node.nodeValue = updated;
+      }
+    }
+
+    if (typeof document.title === "string" && document.title) {
+      const updatedTitle = transform(document.title);
+      if (updatedTitle !== document.title) {
+        document.title = updatedTitle;
+      }
+    }
+
+    document.querySelectorAll("[aria-label]").forEach(element => {
+      const label = element.getAttribute("aria-label");
+      if (label) {
+        const updated = transform(label);
+        if (updated !== label) {
+          element.setAttribute("aria-label", updated);
+        }
+      }
+    });
+
+    textTransformed = true;
+  };
+
+  const applyAccent = () => {
+    if (accentApplied) {
+      return;
+    }
+
+    setAccentColor(BOMBOCLOCK_ACCENT_COLOR, { persist: false });
+    const accentControl = document.getElementById("accentControl");
+    const normalized = normalizeHexColor(BOMBOCLOCK_ACCENT_COLOR);
+    if (accentControl && normalized) {
+      accentControl.value = normalized;
+    }
+    accentApplied = true;
+  };
+
+  brand.addEventListener("click", () => {
+    activationCount += 1;
+    applyReplacements();
+    if (activationCount >= BOMBOCLOCK_ACTIVATION_CLICKS) {
+      applyAccent();
+    }
+  });
+}
+
 function setEditingState(event) {
   const editingId = document.getElementById("editingId");
   const labelInput = document.getElementById("labelInput");
@@ -1340,6 +1431,8 @@ function setEditingState(event) {
       setAccentColor(event.target.value, { persist: true });
     });
   }
+
+  initBomboClockEasterEgg();
 
   initAudioPlayer();
   initShagMeter();

--- a/shagmeter.html
+++ b/shagmeter.html
@@ -72,7 +72,7 @@
           <article class="meter-card shagmeter-card">
             <header class="meter-card__header">
               <h3>ShagMeter</h3>
-              <p>Tel je shaggies tot je doel bereikt is.</p>
+              <p>Tel je Shaggies tot je doel bereikt is.</p>
             </header>
             <div class="shagmeter__goal">
               <label for="shagmeterGoal">Dagelijkse shag goal</label>
@@ -87,7 +87,7 @@
                   data-shagmeter-goal
                   aria-label="Dagelijkse shag goal"
                 />
-                <span class="shagmeter__goal-value" data-shagmeter-goal-value>8 shaggs</span>
+                <span class="shagmeter__goal-value" data-shagmeter-goal-value>8 Shaggies</span>
               </div>
             </div>
 
@@ -104,13 +104,13 @@
                 <div class="shagmeter__pulse" aria-hidden="true"></div>
                 <div class="shagmeter__value">
                   <span class="shagmeter__count" data-shagmeter-count>0</span>
-                  <span class="shagmeter__count-label" data-shagmeter-count-label>shaggs</span>
+                  <span class="shagmeter__count-label" data-shagmeter-count-label>Shaggies</span>
                 </div>
               </div>
               <div class="shagmeter__eruption" data-shagmeter-explosion aria-hidden="true"></div>
             </div>
 
-            <p class="shagmeter__status" data-shagmeter-status>0 van 8 shaggs genoteerd.</p>
+            <p class="shagmeter__status" data-shagmeter-status>0 van 8 Shaggies genoteerd.</p>
 
             <div class="shagmeter__actions">
               <button class="shagmeter__add-btn" type="button" data-shagmeter-add aria-label="Voeg een shaggie toe">+</button>

--- a/style.css
+++ b/style.css
@@ -82,6 +82,15 @@ main {
   display: flex;
   align-items: center;
   gap: 0.75rem;
+  cursor: pointer;
+}
+
+.brand--bombo-hint {
+  animation: brand-bombo-hint 0.5s ease;
+}
+
+.brand--bombo-hint .brand__mark {
+  animation: brand-bombo-glow 0.5s ease;
 }
 
 .brand__mark {
@@ -90,6 +99,41 @@ main {
   border-radius: 16px;
   background: rgba(255, 255, 255, 0.04);
   box-shadow: var(--shadow-md);
+}
+
+.brand--bombo-hint .brand__mark,
+.brand--bombo-hint {
+  will-change: transform, box-shadow;
+}
+
+@keyframes brand-bombo-hint {
+  0% {
+    transform: scale(1) rotate(0deg);
+  }
+  30% {
+    transform: scale(1.08) rotate(-2deg);
+  }
+  55% {
+    transform: scale(0.95) rotate(2deg);
+  }
+  100% {
+    transform: scale(1) rotate(0deg);
+  }
+}
+
+@keyframes brand-bombo-glow {
+  0% {
+    box-shadow: var(--shadow-md);
+  }
+  35% {
+    box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.2), 0 0 18px 6px var(--accent);
+  }
+  70% {
+    box-shadow: 0 0 0 12px rgba(255, 255, 255, 0.12), 0 0 14px 4px var(--accent);
+  }
+  100% {
+    box-shadow: var(--shadow-md);
+  }
 }
 
 .brand__text {


### PR DESCRIPTION
## Summary
- introduce lightweight BomboClock easter egg constants and helpers
- hook the site header brand click to trigger renaming text content and reveal the easter egg accent after three clicks
- ensure the easter egg is initialised alongside existing bootstrapping without impacting other pages

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d543023044832591dc0d122896544c