### PR TITLE
Add Het Archief archive page and styling

### DIFF
--- a/HetArchief/videos.json
+++ b/HetArchief/videos.json
@@ -1,0 +1,19 @@
+{
+  "instructions": "Voeg nieuwe video's toe door een object binnen \"videos\" te kopiëren. Vul minimaal de titel, beschrijving en het pad naar je .mp4-bestand in. Optioneel kun je het MIME-type (type) en een posterafbeelding toevoegen.",
+  "videos": [
+    {
+      "title": "Het verloren shagritueel",
+      "description": "Donaldy Trumpowich schiet te hulp tijdens een vergeten rookceremonie.",
+      "src": "HetArchief/het-verloren-ritueel.mp4",
+      "type": "video/mp4",
+      "poster": ""
+    },
+    {
+      "title": "After hours rookworkshop",
+      "description": "Pieter Hein deelt geavanceerde draaitechnieken met de nachtploeg.",
+      "src": "HetArchief/after-hours-workshop.mp4",
+      "type": "video/mp4",
+      "poster": ""
+    }
+  ]
+}

--- a/gallery.html
+++ b/gallery.html
@@ -44,6 +44,7 @@
           <div class="hero__actions">
             <a class="btn primary" href="#gallery">Bekijk de gallery</a>
             <a class="btn ghost" href="library.html">Ga naar ShagFiles</a>
+            <a class="btn btn--archief" href="het-archief.html" aria-label="Open Hét Archief">Hét Archief</a>
           </div>
         </div>
         <figure class="hero__media gallery-hero__media">

--- a/het-archief.html
+++ b/het-archief.html
@@ -60,7 +60,16 @@
       const archiveContainer = document.querySelector("[data-archive]");
       if (!archiveContainer) return;
 
-      const dataSource = archiveContainer.getAttribute("data-archive-source") || "HetArchief/videos.json";
+      const fallbackSource = "HetArchief/videos.json";
+      const sourceAttr = archiveContainer.getAttribute("data-archive-source");
+
+      let resolvedSource;
+      try {
+        resolvedSource = new URL(sourceAttr || fallbackSource, document.baseURI).href;
+      } catch (error) {
+        console.warn("Onbekende data-URL, val terug op standaardbron.", error);
+        resolvedSource = new URL(fallbackSource, document.baseURI).href;
+      }
 
       const renderPlaceholder = (message, index = null) => {
         const card = document.createElement("article");
@@ -81,17 +90,19 @@
         card.className = "archive-video";
         card.setAttribute("role", "listitem");
 
-        if (item.src) {
+        const src = item?.src?.toString().trim();
+        if (src) {
           const video = document.createElement("video");
           video.className = "archive-video__player";
           video.controls = true;
           video.preload = "metadata";
-          if (item.poster) {
-            video.poster = item.poster;
+          const poster = item?.poster?.toString().trim();
+          if (poster) {
+            video.poster = poster;
           }
 
           const source = document.createElement("source");
-          source.src = item.src;
+          source.src = src;
           source.type = item.type || "video/mp4";
           video.appendChild(source);
           video.insertAdjacentText("beforeend", "Je browser ondersteunt het video-element niet.");
@@ -104,7 +115,7 @@
 
         const title = document.createElement("h3");
         title.className = "archive-video__title";
-        title.textContent = item.title || `Video ${index + 1}`;
+        title.textContent = item.title?.toString().trim() || `Video ${index + 1}`;
         card.appendChild(title);
 
         if (item.description) {
@@ -117,29 +128,50 @@
         archiveContainer.appendChild(card);
       };
 
-      fetch(dataSource)
-        .then((response) => {
+      const hydrateArchive = async () => {
+        if (typeof fetch !== "function") {
+          renderPlaceholder("Je browser ondersteunt het laden van het archief niet.");
+          return;
+        }
+
+        let payload = null;
+        try {
+          const response = await fetch(resolvedSource, { cache: "no-store" });
           if (!response.ok) {
             throw new Error(`Kan archiefdata niet laden (${response.status})`);
           }
-          return response.json();
-        })
-        .then((data) => {
-          if (data && data.instructions) {
-            console.info(`Archiefhandleiding: ${data.instructions}`);
-          }
 
-          if (!data || !Array.isArray(data.videos) || data.videos.length === 0) {
-            renderPlaceholder("Voeg video's toe aan videos.json om ze hier te tonen.");
+          const raw = await response.text();
+          if (!raw.trim()) {
+            renderPlaceholder("videos.json is leeg. Voeg video's toe om ze te tonen.");
             return;
           }
 
-          data.videos.forEach((item, index) => renderVideoCard(item, index));
-        })
-        .catch((error) => {
+          try {
+            payload = JSON.parse(raw);
+          } catch (parseError) {
+            throw new Error("videos.json bevat geen geldige JSON.", { cause: parseError });
+          }
+        } catch (error) {
           console.error(error);
           renderPlaceholder("Kon de archieflijst niet laden. Controleer videos.json.");
-        });
+          return;
+        }
+
+        if (payload?.instructions) {
+          console.info(`Archiefhandleiding: ${payload.instructions}`);
+        }
+
+        const entries = Array.isArray(payload?.videos) ? payload.videos : [];
+        if (entries.length === 0) {
+          renderPlaceholder("Voeg video's toe aan videos.json om ze hier te tonen.");
+          return;
+        }
+
+        entries.forEach((item, index) => renderVideoCard(item, index));
+      };
+
+      hydrateArchive();
     })();
   </script>
 </body>

--- a/het-archief.html
+++ b/het-archief.html
@@ -44,7 +44,7 @@
           </p>
         </header>
 
-        <div class="archive-videos" data-archive role="list"></div>
+        <div class="archive-videos" data-archive data-archive-source="HetArchief/videos.json" role="list"></div>
       </section>
     </main>
 
@@ -60,41 +60,23 @@
       const archiveContainer = document.querySelector("[data-archive]");
       if (!archiveContainer) return;
 
-      /**
-       * Hét Archief onderhoudshandleiding:
-       * 1. Plaats je .mp4 video's in de map /HetArchief/ en noteer de bestandsnamen.
-       * 2. Dupliceer het object ARCHIVE_VIDEO_TEMPLATE hieronder voor iedere nieuwe video.
-       * 3. Vul per video de src (bijv. "HetArchief/mijn-video.mp4"), titel, beschrijving en optionele poster in.
-       * 4. Bewaar het bestand, vernieuw de pagina en test of de video's correct afspelen.
-       */
-      const ARCHIVE_VIDEO_TEMPLATE = {
-        title: "Naam van de video",
-        description: "Korte toelichting bij de video.",
-        src: "HetArchief/jouw-video.mp4", // Vervang door het pad naar jouw video.
-        type: "video/mp4", // Pas aan als je een ander bestandsformaat gebruikt.
-        poster: "" // Optioneel: een poster-afbeelding die getoond wordt vóór het afspelen.
+      const dataSource = archiveContainer.getAttribute("data-archive-source") || "HetArchief/videos.json";
+
+      const renderPlaceholder = (message, index = null) => {
+        const card = document.createElement("article");
+        card.className = "archive-video";
+        card.setAttribute("role", "listitem");
+
+        const placeholder = document.createElement("div");
+        placeholder.className = "archive-video__placeholder";
+        const label = typeof index === "number" ? `Slot ${index + 1}` : "Archief update";
+        placeholder.innerHTML = `${label}<br><span>${message}</span>`;
+
+        card.appendChild(placeholder);
+        archiveContainer.appendChild(card);
       };
 
-      const ARCHIVE_VIDEOS = [
-        {
-          ...ARCHIVE_VIDEO_TEMPLATE,
-          title: "Het verloren shagritueel",
-          description: "Donaldy Trumpowich schiet te hulp tijdens een vergeten rookceremonie.",
-          src: "HetArchief/het-verloren-ritueel.mp4"
-        },
-        {
-          ...ARCHIVE_VIDEO_TEMPLATE,
-          title: "After hours rookworkshop",
-          description: "Pieter Hein deelt geavanceerde draaitechnieken met de nachtploeg.",
-          src: "HetArchief/after-hours-workshop.mp4"
-        }
-      ];
-
-      console.info(
-        "Archief tutorial:\n1) Voeg je .mp4 video's toe aan /HetArchief/.\n2) Dupliceer ARCHIVE_VIDEO_TEMPLATE voor iedere video en vul de velden in.\n3) Herlaad de pagina om de updates te bekijken."
-      );
-
-      ARCHIVE_VIDEOS.forEach((item, index) => {
+      const renderVideoCard = (item, index) => {
         const card = document.createElement("article");
         card.className = "archive-video";
         card.setAttribute("role", "listitem");
@@ -116,10 +98,8 @@
 
           card.appendChild(video);
         } else {
-          const placeholder = document.createElement("div");
-          placeholder.className = "archive-video__placeholder";
-          placeholder.innerHTML = `Slot ${index + 1}<br><span>Voeg een src toe in ARCHIVE_VIDEOS.</span>`;
-          card.appendChild(placeholder);
+          renderPlaceholder("Voeg een src toe in videos.json.", index);
+          return;
         }
 
         const title = document.createElement("h3");
@@ -135,7 +115,31 @@
         }
 
         archiveContainer.appendChild(card);
-      });
+      };
+
+      fetch(dataSource)
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error(`Kan archiefdata niet laden (${response.status})`);
+          }
+          return response.json();
+        })
+        .then((data) => {
+          if (data && data.instructions) {
+            console.info(`Archiefhandleiding: ${data.instructions}`);
+          }
+
+          if (!data || !Array.isArray(data.videos) || data.videos.length === 0) {
+            renderPlaceholder("Voeg video's toe aan videos.json om ze hier te tonen.");
+            return;
+          }
+
+          data.videos.forEach((item, index) => renderVideoCard(item, index));
+        })
+        .catch((error) => {
+          console.error(error);
+          renderPlaceholder("Kon de archieflijst niet laden. Controleer videos.json.");
+        });
     })();
   </script>
 </body>

--- a/het-archief.html
+++ b/het-archief.html
@@ -1,0 +1,142 @@
+<!doctype html>
+<html lang="nl">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ShagWekker · Hét Archief</title>
+  <link rel="stylesheet" href="style.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700&display=swap" rel="stylesheet" />
+</head>
+<body>
+  <div class="page">
+    <header class="site-header" id="top">
+      <div class="brand" aria-label="ShagWekker">
+        <img src="assets/shag.png" alt="Placeholder logo illustration" class="brand__mark" />
+        <div class="brand__text">
+          <span class="brand__name">ShagWekker</span>
+          <span class="brand__tag">Je kan nooit genoeg Shag roken.</span>
+        </div>
+      </div>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="index.html#hero">Shag</a>
+        <a href="index.html#planner">Nicotineteller</a>
+        <a href="index.html#customize">Inlassen</a>
+        <a href="index.html#insights">Insights</a>
+        <a href="shagmeter.html">ShagMeter</a>
+        <a href="gallery.html">Gallery</a>
+        <a href="library.html">ShagFiles</a>
+      </nav>
+      <div class="header-actions">
+        <button class="btn ghost" id="contrastToggle" type="button" aria-pressed="false">High contrast</button>
+      </div>
+    </header>
+
+    <main class="archive">
+      <section class="archive__box" aria-labelledby="archive-heading">
+        <header class="archive__header">
+          <p class="archive__eyebrow">Exclusieve collectie</p>
+          <h1 class="archive__title" id="archive-heading">Hét Archief.</h1>
+          <p class="archive__lead">
+            Een besloten videodossier met bewegend bewijs van de ShagWekker legende. Vul de map <code>HetArchief/</code>
+            met jouw .mp4-bestanden en geef ze hieronder context.
+          </p>
+        </header>
+
+        <div class="archive-videos" data-archive role="list"></div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <p>&copy; <span id="footerYear"></span> ShagWekker. Shag kun je helaas niet eten, maar wel lekker roken.</p>
+      <a class="back-to-top" href="#top">Back to top</a>
+    </footer>
+  </div>
+
+  <script src="script.js"></script>
+  <script>
+    (function initArchiveVideos() {
+      const archiveContainer = document.querySelector("[data-archive]");
+      if (!archiveContainer) return;
+
+      /**
+       * Hét Archief onderhoudshandleiding:
+       * 1. Plaats je .mp4 video's in de map /HetArchief/ en noteer de bestandsnamen.
+       * 2. Dupliceer het object ARCHIVE_VIDEO_TEMPLATE hieronder voor iedere nieuwe video.
+       * 3. Vul per video de src (bijv. "HetArchief/mijn-video.mp4"), titel, beschrijving en optionele poster in.
+       * 4. Bewaar het bestand, vernieuw de pagina en test of de video's correct afspelen.
+       */
+      const ARCHIVE_VIDEO_TEMPLATE = {
+        title: "Naam van de video",
+        description: "Korte toelichting bij de video.",
+        src: "HetArchief/jouw-video.mp4", // Vervang door het pad naar jouw video.
+        type: "video/mp4", // Pas aan als je een ander bestandsformaat gebruikt.
+        poster: "" // Optioneel: een poster-afbeelding die getoond wordt vóór het afspelen.
+      };
+
+      const ARCHIVE_VIDEOS = [
+        {
+          ...ARCHIVE_VIDEO_TEMPLATE,
+          title: "Het verloren shagritueel",
+          description: "Donaldy Trumpowich schiet te hulp tijdens een vergeten rookceremonie.",
+          src: "HetArchief/het-verloren-ritueel.mp4"
+        },
+        {
+          ...ARCHIVE_VIDEO_TEMPLATE,
+          title: "After hours rookworkshop",
+          description: "Pieter Hein deelt geavanceerde draaitechnieken met de nachtploeg.",
+          src: "HetArchief/after-hours-workshop.mp4"
+        }
+      ];
+
+      console.info(
+        "Archief tutorial:\n1) Voeg je .mp4 video's toe aan /HetArchief/.\n2) Dupliceer ARCHIVE_VIDEO_TEMPLATE voor iedere video en vul de velden in.\n3) Herlaad de pagina om de updates te bekijken."
+      );
+
+      ARCHIVE_VIDEOS.forEach((item, index) => {
+        const card = document.createElement("article");
+        card.className = "archive-video";
+        card.setAttribute("role", "listitem");
+
+        if (item.src) {
+          const video = document.createElement("video");
+          video.className = "archive-video__player";
+          video.controls = true;
+          video.preload = "metadata";
+          if (item.poster) {
+            video.poster = item.poster;
+          }
+
+          const source = document.createElement("source");
+          source.src = item.src;
+          source.type = item.type || "video/mp4";
+          video.appendChild(source);
+          video.insertAdjacentText("beforeend", "Je browser ondersteunt het video-element niet.");
+
+          card.appendChild(video);
+        } else {
+          const placeholder = document.createElement("div");
+          placeholder.className = "archive-video__placeholder";
+          placeholder.innerHTML = `Slot ${index + 1}<br><span>Voeg een src toe in ARCHIVE_VIDEOS.</span>`;
+          card.appendChild(placeholder);
+        }
+
+        const title = document.createElement("h3");
+        title.className = "archive-video__title";
+        title.textContent = item.title || `Video ${index + 1}`;
+        card.appendChild(title);
+
+        if (item.description) {
+          const description = document.createElement("p");
+          description.className = "archive-video__description";
+          description.textContent = item.description;
+          card.appendChild(description);
+        }
+
+        archiveContainer.appendChild(card);
+      });
+    })();
+  </script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1255,6 +1255,23 @@ button {
   color: var(--danger);
 }
 
+.btn.btn--archief {
+  padding: 0.4rem 0.9rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  background: linear-gradient(135deg, rgba(255, 235, 175, 0.95), rgba(255, 166, 92, 0.95));
+  color: #2d1a00;
+  box-shadow: 0 14px 32px rgba(255, 180, 90, 0.4);
+  border: 1px solid rgba(255, 208, 128, 0.75);
+}
+
+.btn.btn--archief:hover,
+.btn.btn--archief:focus-visible {
+  transform: translateY(-2px) scale(1.02);
+  box-shadow: 0 18px 42px rgba(255, 196, 110, 0.55);
+}
+
 .customize__board-header {
   display: flex;
   align-items: baseline;
@@ -1402,6 +1419,106 @@ button {
   padding: clamp(1.1rem, 2vw, 1.6rem);
   border: 1px solid rgba(255, 255, 255, 0.08);
   box-shadow: var(--shadow-md);
+}
+
+.archive {
+  justify-content: center;
+  align-items: center;
+  padding: clamp(2rem, 6vw, 4rem);
+}
+
+.archive__box {
+  width: min(100%, 940px);
+  background: linear-gradient(165deg, rgba(20, 30, 62, 0.92), rgba(8, 15, 34, 0.92));
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: var(--shadow-xl);
+  padding: clamp(2rem, 5vw, 3rem);
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2.4rem);
+  margin: 0 auto;
+}
+
+.archive__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.archive__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+  color: var(--muted);
+  margin: 0;
+}
+
+.archive__title {
+  margin: 0;
+  font-size: clamp(2.2rem, 4vw, 3.2rem);
+}
+
+.archive__lead {
+  margin: 0;
+  max-width: 62ch;
+  color: var(--muted);
+}
+
+.archive-videos {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--grid-gap);
+}
+
+.archive-video {
+  background: radial-gradient(circle at top right, rgba(255, 188, 122, 0.18), transparent 62%), var(--surface-strong);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow-md);
+  padding: clamp(1.2rem, 2.4vw, 1.8rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition);
+}
+
+.archive-video:hover,
+.archive-video:focus-within {
+  transform: translateY(-4px);
+  box-shadow: 0 26px 54px rgba(0, 0, 0, 0.45);
+  border-color: rgba(255, 196, 110, 0.45);
+}
+
+.archive-video__player {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border-radius: var(--radius-sm);
+  background: rgba(0, 0, 0, 0.65);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+}
+
+.archive-video__title {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.archive-video__description {
+  margin: 0;
+  color: var(--muted);
+}
+
+.archive-video__placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  aspect-ratio: 16 / 9;
+  border-radius: var(--radius-sm);
+  background: repeating-linear-gradient(135deg, rgba(255, 255, 255, 0.08) 0, rgba(255, 255, 255, 0.08) 16px, transparent 16px, transparent 32px);
+  color: var(--muted);
+  text-align: center;
+  padding: 1.2rem;
+  border: 1px dashed rgba(255, 255, 255, 0.16);
 }
 
 .resource-note h3 {

--- a/style.css
+++ b/style.css
@@ -1496,8 +1496,8 @@ button {
 
 .archive-video__player {
   width: 100%;
-  aspect-ratio: 9 / 16;
-  max-height: min(80vh, 720px);
+  aspect-ratio: 16 / 9;
+  max-height: min(80vh, 640px);
   border-radius: calc(var(--radius-sm) * 1.25);
   background: rgba(0, 0, 0, 0.65);
   box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
@@ -1520,7 +1520,7 @@ button {
   justify-content: center;
   flex-direction: column;
   gap: 0.35rem;
-  aspect-ratio: 9 / 16;
+  aspect-ratio: 16 / 9;
   border-radius: var(--radius-sm);
   background: repeating-linear-gradient(135deg, rgba(255, 255, 255, 0.08) 0, rgba(255, 255, 255, 0.08) 16px, transparent 16px, transparent 32px);
   color: var(--muted);

--- a/style.css
+++ b/style.css
@@ -1423,20 +1423,20 @@ button {
 
 .archive {
   justify-content: center;
-  align-items: center;
+  align-items: stretch;
   padding: clamp(2rem, 6vw, 4rem);
 }
 
 .archive__box {
-  width: min(100%, 940px);
+  width: min(100%, 1080px);
+  min-height: clamp(560px, 85vh, 1200px);
   background: linear-gradient(165deg, rgba(20, 30, 62, 0.92), rgba(8, 15, 34, 0.92));
   border-radius: var(--radius-lg);
   border: 1px solid rgba(255, 255, 255, 0.12);
   box-shadow: var(--shadow-xl);
-  padding: clamp(2rem, 5vw, 3rem);
-  display: flex;
-  flex-direction: column;
-  gap: clamp(1.5rem, 3vw, 2.4rem);
+  padding: clamp(2rem, 5vw, 3.5rem);
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.8rem);
   margin: 0 auto;
 }
 
@@ -1466,20 +1466,24 @@ button {
 }
 
 .archive-videos {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: var(--grid-gap);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(1.5rem, 4vh, 2.8rem);
 }
 
 .archive-video {
+  width: min(100%, clamp(320px, 60vw, 640px));
   background: radial-gradient(circle at top right, rgba(255, 188, 122, 0.18), transparent 62%), var(--surface-strong);
   border-radius: var(--radius-md);
   border: 1px solid rgba(255, 255, 255, 0.08);
   box-shadow: var(--shadow-md);
-  padding: clamp(1.2rem, 2.4vw, 1.8rem);
+  padding: clamp(1rem, 2vw, 1.8rem);
   display: flex;
   flex-direction: column;
-  gap: 0.9rem;
+  gap: 1rem;
+  margin: 0 auto;
+  text-align: left;
   transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition);
 }
 
@@ -1492,10 +1496,12 @@ button {
 
 .archive-video__player {
   width: 100%;
-  aspect-ratio: 16 / 9;
-  border-radius: var(--radius-sm);
+  aspect-ratio: 9 / 16;
+  max-height: min(80vh, 720px);
+  border-radius: calc(var(--radius-sm) * 1.25);
   background: rgba(0, 0, 0, 0.65);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.1);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.12);
+  object-fit: cover;
 }
 
 .archive-video__title {
@@ -1512,7 +1518,9 @@ button {
   display: flex;
   align-items: center;
   justify-content: center;
-  aspect-ratio: 16 / 9;
+  flex-direction: column;
+  gap: 0.35rem;
+  aspect-ratio: 9 / 16;
   border-radius: var(--radius-sm);
   background: repeating-linear-gradient(135deg, rgba(255, 255, 255, 0.08) 0, rgba(255, 255, 255, 0.08) 16px, transparent 16px, transparent 32px);
   color: var(--muted);


### PR DESCRIPTION
## Summary
- add an exclusive Het Archief page with a modular video listing fed by a template array
- create new styling for the archive layout and fancy CTA button linking from the gallery
- prepare a HetArchief/ directory for future mp4 uploads

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d55e4db72c8325b2a21ef993ee3aeb