### PR TITLE
Fix window control clicks and volume tray behavior

### DIFF
--- a/ShagOS/css/shagos.css
+++ b/ShagOS/css/shagos.css
@@ -210,21 +210,27 @@ html {
 .shagos-window__titlebar {
   display: flex;
   align-items: center;
-  gap: 12px;
+  gap: 16px;
   padding: 12px 20px;
   background: rgba(15, 23, 42, 0.35);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
+}
+
+.shagos-window__drag-region {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
   cursor: grab;
   user-select: none;
 }
 
-.shagos-window__titlebar:active {
+.shagos-window__drag-region:active {
   cursor: grabbing;
 }
 
 .shagos-window__title {
-  flex: 1;
   font-size: 0.95rem;
   font-weight: 600;
 }
@@ -232,6 +238,8 @@ html {
 .shagos-window__controls {
   display: flex;
   gap: 8px;
+  padding-left: 12px;
+  border-left: 1px solid rgba(148, 163, 184, 0.18);
 }
 
 .shagos-window__button {
@@ -630,6 +638,7 @@ html {
   box-shadow: var(--shagos-window-shadow);
   backdrop-filter: blur(28px);
   -webkit-backdrop-filter: blur(28px);
+  z-index: 1200;
   transform: translateY(12px);
   opacity: 0;
   pointer-events: none;


### PR DESCRIPTION
## Summary
- prevent the titlebar drag handler from swallowing minimize and close button clicks on desktop
- add a dedicated close button to the taskbar volume popover and keep it visible until dismissed
- style the volume popover header and close affordance to match the existing glassmorphic UI

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d6aa7c3a908325bb6bf01c866b6fcc