### PR TITLE
Add initial ShagWekker API framework and health endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# ShagWekker Repository Agent Guide
+
+## Project layout
+- Frontend pages are static HTML/CSS/JS at repo root.
+- API entrypoint is `api-server.js`.
+
+## API framework direction
+- Keep all new API endpoints versioned under `/api/v1`.
+- Reuse the route registry and shared JSON response helpers in `api-server.js`.
+- Preserve health endpoint semantics at `GET /api/v1/health` for uptime and readiness checks.
+
+## Planned SQL integration
+When SQL support is introduced:
+1. Add a dedicated data-access layer (for example `api/db/`) instead of writing SQL in route handlers.
+2. Add user + meter endpoints under `/api/v1/users` and `/api/v1/meter`.
+3. Keep response payloads stable and additive for backward compatibility.
+4. Store user records and shag meter totals (time + shaggie count) in normalized tables.
+
+## Operational notes
+- Configure host/port with `API_HOST` and `API_PORT`.
+- Use `node api-server.js` to run the API locally.

--- a/api-server.js
+++ b/api-server.js
@@ -1,0 +1,106 @@
+const http = require('http');
+const { URL } = require('url');
+
+const HOST = process.env.API_HOST || '0.0.0.0';
+const PORT = Number(process.env.API_PORT || 3000);
+const API_PREFIX = '/api/v1';
+
+/**
+ * API framework scaffold:
+ * - A lightweight route registry
+ * - Shared response helpers
+ * - Versioned prefix for forwards compatibility
+ * - Central place for future SQL-backed services
+ */
+function createApiApp() {
+  const routes = new Map();
+
+  function routeKey(method, path) {
+    return `${method.toUpperCase()} ${path}`;
+  }
+
+  function register(method, path, handler) {
+    routes.set(routeKey(method, path), handler);
+  }
+
+  function json(res, statusCode, payload) {
+    const body = JSON.stringify(payload);
+    res.writeHead(statusCode, {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Content-Length': Buffer.byteLength(body),
+      'Cache-Control': 'no-store'
+    });
+    res.end(body);
+  }
+
+  function notFound(res, pathname) {
+    json(res, 404, {
+      error: 'not_found',
+      message: `No route for ${pathname}`
+    });
+  }
+
+  function withErrorBoundary(handler) {
+    return async (req, res) => {
+      try {
+        await handler(req, res);
+      } catch (error) {
+        json(res, 500, {
+          error: 'internal_error',
+          message: 'An unexpected error occurred.',
+          details: error instanceof Error ? error.message : String(error)
+        });
+      }
+    };
+  }
+
+  register('GET', `${API_PREFIX}/health`, withErrorBoundary(async (_req, res) => {
+    json(res, 200, {
+      status: 'ok',
+      service: 'ShagWekker API',
+      version: 'v1',
+      timestamp: new Date().toISOString(),
+      uptimeSeconds: Number(process.uptime().toFixed(2)),
+      environment: process.env.NODE_ENV || 'development',
+      capabilities: {
+        health: true,
+        meter: false,
+        users: false,
+        sqlStorage: false
+      },
+      notes: 'Framework is live. SQL-backed meter/user endpoints can now be added under /api/v1.'
+    });
+  }));
+
+  register('GET', `${API_PREFIX}`, withErrorBoundary(async (_req, res) => {
+    json(res, 200, {
+      service: 'ShagWekker API',
+      version: 'v1',
+      endpoints: {
+        health: `${API_PREFIX}/health`
+      }
+    });
+  }));
+
+  return {
+    async handle(req, res) {
+      const url = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+      const key = routeKey(req.method || 'GET', url.pathname);
+      const handler = routes.get(key);
+
+      if (!handler) {
+        notFound(res, url.pathname);
+        return;
+      }
+
+      await handler(req, res);
+    }
+  };
+}
+
+const app = createApiApp();
+const server = http.createServer((req, res) => app.handle(req, res));
+
+server.listen(PORT, HOST, () => {
+  console.log(`[ShagWekker API] listening on http://${HOST}:${PORT}${API_PREFIX}`);
+});


### PR DESCRIPTION
### Motivation
- Provide a minimal, consistent API scaffold to host future endpoints and centralize HTTP handling in `api-server.js`.
- Expose a health/readiness overview now while preparing for future SQL-backed user and meter storage under a versioned API prefix.

### Description
- Add `api-server.js`, a lightweight Node.js HTTP app with a route registry, JSON response helper, 404 handling, and an async error boundary for consistent handlers.
- Introduce versioned routing under `/api/v1` and implement `GET /api/v1/health` returning status, uptime, timestamp, environment, and capability flags, and `GET /api/v1` as a service index.
- Add `AGENTS.md` at the repo root documenting API conventions, operational notes, and a planned SQL integration path for `users` and `meter` endpoints.
- Make host/port configurable via `API_HOST` and `API_PORT` and keep the framework intentionally minimal to ease future extension.

### Testing
- Ran `node --check api-server.js` which completed successfully.
- Launched the server and queried the endpoint with `curl http://127.0.0.1:3000/api/v1/health` and received the expected JSON health payload.
- Both automated checks and the runtime endpoint verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f258c54e84832596182a424ac8c333)