### PR TITLE
ShagMeter: vervang slider door tekstveld, hef cap van 20 op

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,15 +146,18 @@
             <div class="shagmeter__goal-control">
               <input
                 id="shagmeterGoal"
-                type="range"
+                class="shagmeter__goal-number"
+                type="number"
                 min="1"
-                max="20"
+                max="9999"
                 step="1"
                 value="8"
+                inputmode="numeric"
+                autocomplete="off"
                 data-shagmeter-goal
                 aria-label="Dagelijkse shag goal"
               />
-              <span class="shagmeter__goal-value" data-shagmeter-goal-value>8 Shaggies</span>
+              <span class="shagmeter__goal-unit" data-shagmeter-goal-value>Shaggies</span>
             </div>
           </div>
 

--- a/script.js
+++ b/script.js
@@ -1584,15 +1584,15 @@ function initShagMeter() {
   renderTimelineCard();
   setInterval(renderTimelineCard, 1000);
 
-  const sliderMin = Number(goalInput.min) || 1;
-  const sliderMax = Number(goalInput.max) || 20;
+  const goalMin = Number(goalInput.min) || 1;
+  const goalMax = Number(goalInput.max) || 9999;
 
   const clampGoal = value => {
     const numeric = Number(value);
     if (!Number.isFinite(numeric) || numeric <= 0) {
-      return sliderMin;
+      return goalMin;
     }
-    return Math.min(sliderMax, Math.max(sliderMin, Math.round(numeric)));
+    return Math.min(goalMax, Math.max(goalMin, Math.round(numeric)));
   };
 
   const shagUnit = amount => {
@@ -1641,7 +1641,7 @@ function initShagMeter() {
     }
   };
 
-  const defaultGoal = clampGoal(goalInput.value || sliderMin);
+  const defaultGoal = clampGoal(goalInput.value || goalMin);
   let state = loadState() || { goal: defaultGoal, count: 0 };
 
   let lastCompletionState = state.count >= state.goal && state.goal > 0;
@@ -1654,7 +1654,7 @@ function initShagMeter() {
   }
 
   const updateGoalValue = () => {
-    goalValueEl.textContent = pluralizeShag(state.goal);
+    goalValueEl.textContent = shagUnit(state.goal);
   };
 
   const stopExplosion = () => {
@@ -1736,8 +1736,23 @@ function initShagMeter() {
   updateMeter();
 
   goalInput.addEventListener("input", event => {
-    state.goal = clampGoal(event.target.value);
-    goalInput.value = state.goal;
+    const raw = event.target.value;
+    if (raw === "" || raw === "-") return;
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed) || parsed < 1) return;
+    state.goal = clampGoal(raw);
+    if (state.count > state.goal) {
+      state.count = state.goal;
+    }
+    updateGoalValue();
+    updateMeter();
+    persistState(state);
+  });
+
+  goalInput.addEventListener("change", event => {
+    const clamped = clampGoal(event.target.value || state.goal);
+    state.goal = clamped;
+    goalInput.value = clamped;
     if (state.count > state.goal) {
       state.count = state.goal;
     }

--- a/shagmeter.html
+++ b/shagmeter.html
@@ -95,15 +95,18 @@
               <div class="shagmeter__goal-control">
                 <input
                   id="shagmeterGoal"
-                  type="range"
+                  class="shagmeter__goal-number"
+                  type="number"
                   min="1"
-                  max="20"
+                  max="9999"
                   step="1"
                   value="8"
+                  inputmode="numeric"
+                  autocomplete="off"
                   data-shagmeter-goal
                   aria-label="Dagelijkse shag goal"
                 />
-                <span class="shagmeter__goal-value" data-shagmeter-goal-value>8 Shaggies</span>
+                <span class="shagmeter__goal-unit" data-shagmeter-goal-value>Shaggies</span>
               </div>
             </div>
 

--- a/style.css
+++ b/style.css
@@ -484,16 +484,44 @@ main {
 .shagmeter__goal-control {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
-.shagmeter__goal-control input[type="range"] {
-  flex: 1;
-  accent-color: var(--accent);
+.shagmeter__goal-number {
+  width: 5.5rem;
+  padding: 0.45rem 0.8rem;
+  font-size: 1.1rem;
+  font-weight: 700;
+  text-align: center;
+  font-family: inherit;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1.5px solid rgba(255, 255, 255, 0.15);
+  border-radius: 999px;
+  color: var(--text);
+  outline: none;
+  transition: border-color 200ms ease, box-shadow 200ms ease, background 200ms ease;
+  -moz-appearance: textfield;
+  appearance: textfield;
 }
 
-.shagmeter__goal-value {
+.shagmeter__goal-number::-webkit-outer-spin-button,
+.shagmeter__goal-number::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.shagmeter__goal-number:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 18%, transparent);
+  background: rgba(255, 255, 255, 0.09);
+}
+
+.shagmeter__goal-unit {
   font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.85rem;
+  color: var(--muted);
 }
 
 .shagmeter__display {

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = "shagwekker-v2";
+const CACHE_NAME = "shagwekker-v3";
 const SHELL = [
   "/",
   "/index.html",


### PR DESCRIPTION
- Range-slider vervangen door een stijlvol pill-vormig number input
- Maximum doel verhoogd van 20 naar 9999 Shaggies
- Input-handler gesplitst in 'input' (live update) + 'change' (afronding)
- Spinner-pijltjes verborgen via CSS, accent-glow bij focus
- Goal-value label toont nu alleen eenheid (shaggie/Shaggies)
- Service worker cache gebumpt naar v3

https://claude.ai/code/session_017hAMYGFuSvANTdm8DiWZ9t